### PR TITLE
feat: add upfront issue type classification to creating-issues skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "nmg-sdlc",
       "source": "./plugins/nmg-sdlc",
       "description": "BDD spec-driven development: issue creation, specifications, verification, and PR workflows.",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "keywords": ["sdlc", "bdd", "gherkin", "specifications", "github-issues"]
     }
   ]

--- a/.claude/specs/21-upfront-issue-type-classification/design.md
+++ b/.claude/specs/21-upfront-issue-type-classification/design.md
@@ -1,0 +1,211 @@
+# Design: Upfront Issue Type Classification
+
+**Issue**: #21
+**Date**: 2026-02-15
+**Status**: Draft
+**Author**: Claude
+
+---
+
+## Overview
+
+This feature modifies the creating-issues skill (`plugins/nmg-sdlc/skills/creating-issues/SKILL.md`) to add upfront type classification and type-specific codebase investigation before the interview phase. The change is entirely within a single Markdown skill definition — no new files, templates, or code are required.
+
+The current 6-step workflow will be restructured to insert a classification step immediately after context gathering, followed by a type-specific investigation step. The existing interview, synthesis, review, and creation steps are then adapted to use the classified type. The skill's `allowed-tools` frontmatter already includes `Read`, `Glob`, and `Grep` (currently unused), so no frontmatter changes are needed for investigation capabilities.
+
+The two issue body templates (feature/enhancement and bug report) will each gain one new section: "Current State" for enhancements and "Root Cause Analysis" for bugs.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+creating-issues SKILL.md (single file modification)
+┌────────────────────────────────────────────────────────────────┐
+│  Step 1: Gather Context          (existing, minor update)      │
+│  Step 2: Classify Issue Type     (NEW — AskUserQuestion)       │
+│  Step 3: Investigate Codebase    (NEW — type-specific)         │
+│     ├── Enhancement path: specs + source exploration           │
+│     └── Bug path: search, trace, hypothesize, confirm          │
+│  Step 4: Interview the User      (existing, adapted per type)  │
+│  Step 5: Synthesize into Issue   (existing, new sections)      │
+│  Step 6: Present Draft for Review (unchanged)                  │
+│  Step 7: Create the Issue        (unchanged)                   │
+│  Step 8: Output                  (unchanged)                   │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+1. User invokes /creating-issues [optional argument]
+2. Step 1: Read argument + steering docs (existing)
+3. Step 2: AskUserQuestion → "Bug" or "Enhancement/Feature"
+4. Step 3: Based on classification:
+   ├── Enhancement: Glob .claude/specs/ → Read relevant specs
+   │                Glob/Grep source files → Read patterns
+   │                → Produce "Current State" summary
+   └── Bug:         Grep codebase for related code
+                    Read affected files, trace paths
+                    → Produce root cause hypothesis
+                    → AskUserQuestion to confirm hypothesis
+5. Step 4: Type-adapted interview (existing questions filtered by type)
+6. Step 5: Synthesize issue body with new section included
+7. Step 6–8: Review, create, output (unchanged)
+```
+
+---
+
+## Detailed Design
+
+### Step 2: Classify Issue Type (NEW)
+
+Insert immediately after Step 1 (Gather Context). Uses `AskUserQuestion` with two options:
+
+| Option | Label | Description |
+|--------|-------|-------------|
+| Bug | "Bug" | "Something is broken or behaving incorrectly" |
+| Enhancement/Feature | "Enhancement / Feature" | "New capability or improvement to existing behavior" |
+
+**Auto-mode bypass**: This step is skipped entirely. Auto-mode already skips the interview (Step 2 in current skill → Step 4 in new skill), so classification is not needed. The existing auto-mode instructions are updated to reference the new step numbers.
+
+**If argument provides a clear signal** (e.g., user said "fix the broken X" or "add Y feature"), the skill should still ask the classification question — the argument seeds the interview, not the classification.
+
+### Step 3: Investigate Codebase (NEW)
+
+Two branches based on classification result:
+
+#### Enhancement Path
+
+1. **Explore existing specs**: `Glob` for `.claude/specs/*/requirements.md` and read any that relate to the area the user described
+2. **Explore source code**: Use `Glob` and `Grep` to find files related to the enhancement area (e.g., if enhancing the creating-issues skill, find the SKILL.md, any templates, related hooks)
+3. **Summarize findings**: Produce a "Current State" summary capturing:
+   - What exists today (relevant code, patterns, specs)
+   - How the current implementation works
+   - What patterns should be preserved or built upon
+
+If no relevant code or specs are found, note that explicitly and move on.
+
+#### Bug Path
+
+1. **Search for related code**: Use `Grep` to find code related to the bug description (error messages, function names, file patterns the user mentioned)
+2. **Trace code paths**: `Read` the relevant files, follow the logic through the affected paths
+3. **Form hypothesis**: Based on the investigation, formulate a root cause hypothesis describing:
+   - What code is involved
+   - What the incorrect behavior/assumption is
+   - Why it manifests as the reported bug
+4. **Confirm with user**: Present the hypothesis via `AskUserQuestion` with options like "Yes, that matches" / "Not quite — let me clarify"
+5. If the user says "not quite", ask a follow-up clarifying question and revise the hypothesis
+
+If investigation is inconclusive, note that and proceed with the user's description alone.
+
+### Step 4: Interview the User (MODIFIED)
+
+The existing Step 2 (Interview) becomes Step 4. The adaptive interview topics are restructured into two explicit branches:
+
+**Enhancement questions** (skip any already answered via argument or investigation):
+1. Who benefits from this? (persona/role)
+2. What's the current pain point or gap?
+3. What's the desired outcome?
+4. What are the key acceptance criteria? (Given/When/Then)
+5. What's in scope vs out of scope?
+6. What's the priority? (MoSCoW)
+
+**Bug questions** (skip any already answered):
+1. What are the exact reproduction steps?
+2. What's expected vs actual behavior?
+3. What environment does this occur in?
+4. How often does it happen?
+5. Any error messages or stack traces?
+6. When did this start? Recent changes?
+
+This replaces the current "adapt questions based on the type of work" guidance with explicit type-specific question lists.
+
+### Step 5: Synthesize into Issue Body (MODIFIED)
+
+Both templates gain a new section. The section placement is between "## Background" and "## Acceptance Criteria".
+
+#### Enhancement Template Addition
+
+```markdown
+## Current State
+
+[Summary from Step 3 investigation — what exists today, relevant code patterns,
+existing specs, and how the current implementation works. If no relevant code
+was found, state that this is a greenfield addition.]
+```
+
+#### Bug Report Template Addition
+
+```markdown
+## Root Cause Analysis
+
+[Hypothesis from Step 3 investigation — affected code paths, the incorrect
+assumption or logic, and triggering conditions. If investigation was
+inconclusive, state what is known and what needs further investigation.]
+
+**User Confirmed**: Yes / Partially / Investigation inconclusive
+```
+
+### Steps 6–8: Unchanged
+
+Steps 6 (Review), 7 (Create Issue), and 8 (Output) are unchanged. The review step naturally covers the new sections since the user sees the full draft.
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Infer type from argument** | Use LLM judgment to auto-classify from the user's description | No extra question | Unreliable for ambiguous descriptions; removes user agency | Rejected — classification should be explicit |
+| **B: Three-option classification** | Separate "Feature" and "Enhancement" options | Finer granularity | Issue already groups feature/enhancement; bug vs non-bug is the meaningful distinction for investigation | Rejected — two options is cleaner |
+| **C: Use Task/Explore subagent for investigation** | Delegate codebase exploration to a subagent | Deeper exploration, protects main context | Slower, heavier; investigation scope is bounded enough for direct Glob/Grep/Read | Rejected — direct tool use is sufficient |
+| **D: Explicit question per step** | Ask classification via `AskUserQuestion` | Clear, explicit, user chooses | **Selected** — aligns with human-in-loop principle |
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Skill definition | BDD (Gherkin) | All 7 acceptance criteria become scenarios |
+| Skill behavior | Manual testing | Install plugin locally, run `/creating-issues` for both bug and enhancement paths |
+| Auto-mode | Manual testing | Verify auto-mode behavior unchanged with `.claude/auto-mode` present |
+
+Since nmg-plugins is a template/plugin repository (not a runtime application), verification is done through the `/verifying-specs` skill and manual testing via `/installing-locally`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Investigation adds excessive latency to issue creation | Medium | Low | Scope investigation to targeted Glob/Grep (not exhaustive scans); set expectation in skill text |
+| Bug investigation hypothesis is wrong | Medium | Low | Always confirm with user before including; clearly label as hypothesis |
+| Auto-mode regression | Low | High | Auto-mode section explicitly skips new steps; test both paths |
+| Existing issue creation quality regresses | Low | Medium | Steps 6–8 unchanged; only new content is additive (new sections) |
+
+---
+
+## Open Questions
+
+- None — all design decisions resolved.
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Architecture follows existing project patterns (per `structure.md`) — single SKILL.md modification, no new files
+- [x] All interface changes documented — new workflow steps and template sections fully specified
+- [x] No database/storage changes
+- [x] No state management changes
+- [x] No UI component changes
+- [x] Security considerations — N/A (no new auth, no new data exposure)
+- [x] Performance impact analyzed — investigation adds Glob/Grep calls, bounded by targeted search
+- [x] Testing strategy defined — BDD scenarios + manual testing
+- [x] Alternatives considered and documented
+- [x] Risks identified with mitigations

--- a/.claude/specs/21-upfront-issue-type-classification/feature.gherkin
+++ b/.claude/specs/21-upfront-issue-type-classification/feature.gherkin
@@ -1,0 +1,74 @@
+# File: .claude/specs/21-upfront-issue-type-classification/feature.gherkin
+#
+# Generated from: .claude/specs/21-upfront-issue-type-classification/requirements.md
+# Issue: #21
+
+Feature: Upfront Issue Type Classification
+  As a developer using the creating-issues skill
+  I want the skill to proactively classify the issue type and perform type-specific codebase investigation
+  So that issues are created with richer context for downstream SDLC phases
+
+  # --- Happy Path ---
+
+  Scenario: Upfront Type Classification
+    Given the user invokes "/creating-issues" with or without an argument
+    When the interview begins after gathering context
+    Then the very first question asks whether this is a "Bug" or "Enhancement / Feature"
+    And the question is presented via AskUserQuestion with descriptive options
+
+  # --- Enhancement Path ---
+
+  Scenario: Enhancement Path — Codebase Exploration
+    Given the user selects "Enhancement / Feature" as the issue type
+    When the skill gathers context for the enhancement
+    Then it searches existing specs in ".claude/specs/" for relevant areas
+    And examines relevant source code using Glob and Grep
+    And produces a "Current State" summary of what exists today
+
+  Scenario: Current State Section in Enhancement Issues
+    Given the enhancement investigation has completed
+    When the issue body is synthesized in Step 5
+    Then the issue body includes a "Current State" section
+    And the section is placed between "Background" and "Acceptance Criteria"
+    And the section summarizes the codebase exploration findings
+
+  # --- Bug Path ---
+
+  Scenario: Bug Path — Root Cause Investigation
+    Given the user selects "Bug" as the issue type
+    When the skill gathers context for the bug
+    Then it searches the codebase for related code using Grep
+    And traces code paths by reading affected files
+    And forms a root cause hypothesis
+    And presents the hypothesis to the user for confirmation via AskUserQuestion
+
+  Scenario: Root Cause Section in Bug Issues
+    Given the bug investigation has completed and the user confirmed the hypothesis
+    When the issue body is synthesized in Step 5
+    Then the issue body includes a "Root Cause Analysis" section
+    And the section contains the hypothesis and relevant code references
+    And the section includes the user's confirmation status
+
+  # --- Auto-mode ---
+
+  Scenario: Automation Mode Unchanged
+    Given the ".claude/auto-mode" file exists in the project directory
+    When the creating-issues skill is invoked
+    Then the classification step is skipped
+    And the investigation step is skipped
+    And the interview step is skipped
+    And issue creation follows the existing auto-mode path unchanged
+
+  # --- Interview Adaptation ---
+
+  Scenario: Interview Flow Adapts for Enhancement
+    Given the issue type has been classified as "Enhancement / Feature"
+    When the remaining interview questions are asked in Step 4
+    Then questions focus on persona, pain point, desired outcome, acceptance criteria, scope, and priority
+    And reproduction-specific questions are not asked
+
+  Scenario: Interview Flow Adapts for Bug
+    Given the issue type has been classified as "Bug"
+    When the remaining interview questions are asked in Step 4
+    Then questions focus on reproduction steps, expected vs actual behavior, environment, frequency, error output, and recent changes
+    And enhancement-specific questions like impact assessment are not asked

--- a/.claude/specs/21-upfront-issue-type-classification/requirements.md
+++ b/.claude/specs/21-upfront-issue-type-classification/requirements.md
@@ -1,0 +1,238 @@
+# Requirements: Upfront Issue Type Classification
+
+**Issue**: #21
+**Date**: 2026-02-15
+**Status**: Draft
+**Author**: Claude
+
+---
+
+## User Story
+
+**As a** developer using the creating-issues skill
+**I want** the skill to proactively classify the issue type (bug vs enhancement) and perform type-specific codebase investigation before drafting
+**So that** issues are created with richer context — current-state analysis for enhancements and root-cause investigation for bugs — improving quality of downstream spec writing and implementation
+
+---
+
+## Background
+
+The creating-issues skill currently has type-specific interview guidance (feature vs bug vs enhancement) but it's passive — it adapts its questions based on what emerges during the interview rather than proactively branching the workflow. This means:
+
+- For **enhancements**, issues are drafted without understanding the current state of the codebase, leading to specs that may miss existing patterns or capabilities.
+- For **bugs**, issues capture only what the user reports without investigating the codebase to identify root causes, leaving that work entirely to the spec/implementation phase.
+
+By adding upfront classification and type-specific investigation steps, issues will contain richer, more actionable context from the start. This is the first step in the SDLC pipeline — higher quality issues cascade into better specs, implementations, and verifications.
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Upfront Type Classification — Happy Path
+
+**Given** the user invokes `/creating-issues` (with or without an argument)
+**When** the interview begins
+**Then** the very first question asks whether this is a bug or an enhancement/feature, before any other interview questions
+
+**Example**:
+- Given: User runs `/creating-issues "improve search performance"`
+- When: The skill begins the interview
+- Then: The first question presented is "Is this a bug or an enhancement/feature?" (via `AskUserQuestion`)
+
+### AC2: Enhancement Path — Codebase Exploration
+
+**Given** the user selects "enhancement" as the issue type
+**When** the skill gathers context for the enhancement
+**Then** it explores existing specs in `.claude/specs/` for relevant areas and examines relevant source code to understand the current state, and includes a "Current State" summary section in the issue body
+
+**Example**:
+- Given: User classifies issue as "enhancement" for improving the writing-specs skill
+- When: The skill investigates the codebase
+- Then: It reads existing specs related to the area, examines the current SKILL.md, and adds a "Current State" section describing what exists today
+
+### AC3: Bug Path — Root Cause Investigation
+
+**Given** the user selects "bug" as the issue type
+**When** the skill gathers context for the bug
+**Then** it actively searches the codebase using Glob/Grep, traces code paths, forms a root cause hypothesis, confirms findings with the user via `AskUserQuestion`, and includes the analysis in the issue body
+
+**Example**:
+- Given: User classifies issue as "bug" about spec drift hook missing files
+- When: The skill investigates the bug
+- Then: It searches for the hook implementation, traces the logic, hypothesizes the root cause, asks the user "Does this root cause analysis look correct?", and includes it in the issue
+
+### AC4: Automation Mode Unchanged
+
+**Given** the `.claude/auto-mode` file exists
+**When** the creating-issues skill is invoked
+**Then** behavior is unchanged — automation mode does not add type-classification or investigation steps (auto-mode skips the interview entirely, so there is no classification step to add)
+
+**Example**:
+- Given: `.claude/auto-mode` exists and user runs `/creating-issues "add logging"`
+- When: The skill executes in auto-mode
+- Then: It follows the existing auto-mode path (skip interview, generate ACs from argument) with no changes
+
+### AC5: Interview Flow Adapts After Classification
+
+**Given** the issue type has been classified as bug or enhancement
+**When** the remaining interview questions are asked
+**Then** only type-relevant questions are presented (reproduction steps and environment for bugs; desired improvement, current pain, and impact for enhancements)
+
+**Example**:
+- Given: User classified the issue as "bug"
+- When: The interview continues
+- Then: Questions focus on reproduction steps, expected vs actual behavior, environment, and error output — not user story or impact assessment
+
+### AC6: Current State Section in Enhancement Issues
+
+**Given** the enhancement investigation has completed
+**When** the issue body is synthesized
+**Then** the issue body includes a "## Current State" section between "## Background" and "## Acceptance Criteria" summarizing what the codebase exploration found
+
+**Example**:
+- Given: Investigation found the creating-issues skill has passive type adaptation in Step 2
+- When: The issue body is drafted
+- Then: A "## Current State" section documents the current behavior, relevant code locations, and existing patterns
+
+### AC7: Root Cause Section in Bug Issues
+
+**Given** the bug investigation has completed and the user has confirmed the hypothesis
+**When** the issue body is synthesized
+**Then** the issue body includes a "## Root Cause Analysis" section with the hypothesis and relevant code references
+
+**Example**:
+- Given: Investigation found the hook reads from a stale file list
+- When: The issue body is drafted
+- Then: A "## Root Cause Analysis" section documents the hypothesis, affected code paths, and user confirmation
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: Upfront Issue Type Classification
+  As a developer using the creating-issues skill
+  I want the skill to proactively classify the issue type and perform type-specific investigation
+  So that issues are created with richer context for downstream SDLC phases
+
+  Scenario: Upfront Type Classification — Happy Path
+    Given the user invokes "/creating-issues" with or without an argument
+    When the interview begins
+    Then the very first question asks whether this is a bug or an enhancement/feature
+
+  Scenario: Enhancement Path — Codebase Exploration
+    Given the user selects "enhancement" as the issue type
+    When the skill gathers context for the enhancement
+    Then it explores existing specs and source code for the relevant area
+    And includes a "Current State" summary in the issue body
+
+  Scenario: Bug Path — Root Cause Investigation
+    Given the user selects "bug" as the issue type
+    When the skill gathers context for the bug
+    Then it searches the codebase and traces code paths
+    And forms a root cause hypothesis
+    And confirms findings with the user
+    And includes the analysis in the issue body
+
+  Scenario: Automation Mode Unchanged
+    Given the ".claude/auto-mode" file exists
+    When the creating-issues skill is invoked
+    Then behavior is unchanged from the current auto-mode path
+
+  Scenario: Interview Flow Adapts After Classification
+    Given the issue type has been classified
+    When the remaining interview questions are asked
+    Then only type-relevant questions are presented
+
+  Scenario: Current State Section in Enhancement Issues
+    Given the enhancement investigation has completed
+    When the issue body is synthesized
+    Then the issue body includes a "Current State" section
+
+  Scenario: Root Cause Section in Bug Issues
+    Given the bug investigation has completed and the user confirmed the hypothesis
+    When the issue body is synthesized
+    Then the issue body includes a "Root Cause Analysis" section
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | Add upfront bug/enhancement/feature classification as the first interview question using `AskUserQuestion` | Must | Before any other interview questions |
+| FR2 | Enhancement path: explore existing specs in `.claude/specs/` and relevant source code; include "Current State" summary in issue body | Must | Uses Glob, Grep, Read tools |
+| FR3 | Bug path: search codebase, trace code paths, form root cause hypothesis, confirm with user via `AskUserQuestion` | Must | Present findings as hypothesis for user confirmation |
+| FR4 | Preserve existing automation mode behavior unchanged | Must | Auto-mode skips interview; no classification needed |
+| FR5 | Adapt remaining interview questions based on classified type | Should | Bug → reproduction-focused; Enhancement → improvement-focused |
+| FR6 | Include "Current State" section in enhancement issue body template | Must | Placed between Background and Acceptance Criteria |
+| FR7 | Include "Root Cause Analysis" section in bug issue body template | Must | Placed between Background and Acceptance Criteria |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Investigation step should complete within a reasonable time; use targeted Glob/Grep rather than exhaustive codebase scans |
+| **Reliability** | If investigation finds no relevant code or specs, gracefully skip the investigation section and note that no existing code was found |
+| **Usability** | Classification question should use `AskUserQuestion` with clear options (Bug, Enhancement/Feature) |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- [x] Creating-issues skill exists (`plugins/nmg-sdlc/skills/creating-issues/SKILL.md`)
+- [x] Steering documents exist (`.claude/steering/product.md`, `tech.md`, `structure.md`)
+
+### External Dependencies
+- [x] `gh` CLI for issue creation
+- [x] Claude Code `AskUserQuestion` tool for classification prompt
+
+### Blocked By
+- None
+
+---
+
+## Out of Scope
+
+- Changes to automation mode behavior (explicitly excluded per AC4)
+- Changes to the bug report or enhancement issue templates' structure (content is richer, but sections remain the same except for the new Current State / Root Cause Analysis sections)
+- Changes to other SDLC skills (writing-specs, implementing-specs, etc.)
+- Automated codebase investigation without user confirmation (bug path always confirms hypothesis)
+- Adding new labels or GitHub project integration
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Issue context quality | Enhancement issues include current-state analysis | Presence of "Current State" section in created issues |
+| Bug diagnosis quality | Bug issues include root cause hypothesis | Presence of "Root Cause Analysis" section in created issues |
+| Downstream spec quality | Specs reference issue investigation findings | Writing-specs skill can leverage richer issue content |
+
+---
+
+## Open Questions
+
+- [x] Should the classification offer two options (Bug, Enhancement) or three (Bug, Feature, Enhancement)? — Per issue, two options: Bug vs Enhancement/Feature (combined)
+- [ ] Should the investigation step use `Task` with `subagent_type='Explore'` for deeper codebase exploration, or direct Glob/Grep calls? — To be decided in design phase
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases and error states are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented (or resolved)

--- a/.claude/specs/21-upfront-issue-type-classification/tasks.md
+++ b/.claude/specs/21-upfront-issue-type-classification/tasks.md
@@ -1,0 +1,131 @@
+# Tasks: Upfront Issue Type Classification
+
+**Issue**: #21
+**Date**: 2026-02-15
+**Status**: Planning
+**Author**: Claude
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 1 | [ ] |
+| Skill Modification | 4 | [ ] |
+| Testing | 1 | [ ] |
+| **Total** | **6** | |
+
+---
+
+## Phase 1: Setup
+
+### T001: Update auto-mode section and step numbering scaffold
+
+**File(s)**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] Auto-mode section references new step numbers (skip Steps 2, 3, 4 instead of just Step 2; skip Step 6 instead of Step 4)
+- [ ] Existing Steps 2–6 renumbered to Steps 4–8 to make room for new Steps 2 and 3
+- [ ] All internal step references updated to match new numbering
+- [ ] No content changes yet — just structural renumbering
+
+**Notes**: Do this first to establish the correct structure before adding new content. The renumbering is: old Step 2 → Step 4, old Step 3 → Step 5, old Step 4 → Step 6, old Step 5 → Step 7, old Step 6 → Step 8.
+
+---
+
+## Phase 2: Skill Modification
+
+### T002: Add Step 2 — Classify Issue Type
+
+**File(s)**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md`
+**Type**: Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] New "### Step 2: Classify Issue Type" section inserted after Step 1
+- [ ] Uses `AskUserQuestion` with two options: "Bug" and "Enhancement / Feature"
+- [ ] Includes descriptions for each option ("Something is broken or behaving incorrectly" / "New capability or improvement to existing behavior")
+- [ ] Notes that auto-mode skips this step
+
+### T003: Add Step 3 — Investigate Codebase
+
+**File(s)**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] New "### Step 3: Investigate Codebase" section inserted after Step 2
+- [ ] Enhancement sub-path: Glob for `.claude/specs/*/requirements.md`, Grep/Read relevant source code, produce "Current State" summary
+- [ ] Bug sub-path: Grep for related code, Read and trace paths, form root cause hypothesis, confirm with user via `AskUserQuestion`
+- [ ] Graceful fallback if investigation finds nothing relevant
+- [ ] Notes that auto-mode skips this step
+
+### T004: Modify Step 4 — Type-adapted interview questions
+
+**File(s)**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md`
+**Type**: Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] Existing interview step restructured with explicit type-specific question lists
+- [ ] Enhancement questions: persona, pain point, desired outcome, ACs (Given/When/Then), scope, priority
+- [ ] Bug questions: reproduction steps, expected vs actual, environment, frequency, error output, when it started
+- [ ] "Skip any already answered" guidance preserved for both paths
+- [ ] Existing adaptive guidance ("Adapt questions based on the type of work") replaced by explicit branches
+
+### T005: Modify Step 5 — Add new sections to issue body templates
+
+**File(s)**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md`
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] Feature/Enhancement template gains "## Current State" section between "## Background" and "## Acceptance Criteria"
+- [ ] Bug Report template gains "## Root Cause Analysis" section between "## Bug Report" summary and "## Reproduction Steps"
+- [ ] Current State section includes placeholder for investigation findings
+- [ ] Root Cause Analysis section includes hypothesis text and "User Confirmed: Yes / Partially / Investigation inconclusive" field
+- [ ] Both new sections reference Step 3 investigation output
+
+---
+
+## Phase 3: Testing
+
+### T006: Create BDD feature file
+
+**File(s)**: `.claude/specs/21-upfront-issue-type-classification/feature.gherkin`
+**Type**: Create
+**Depends**: T002, T003, T004, T005
+**Acceptance**:
+- [ ] All 7 acceptance criteria from requirements.md have corresponding scenarios
+- [ ] Feature file uses valid Gherkin syntax
+- [ ] Scenarios are independent and self-contained
+- [ ] Includes happy path, alternative paths, and edge cases
+
+---
+
+## Dependency Graph
+
+```
+T001 (renumber steps)
+  ├──▶ T002 (classify) ──▶ T003 (investigate)
+  │                              │
+  └──▶ T004 (interview)         │
+                                 │
+               T005 (templates) ◀┘
+                    │
+                    ▼
+              T006 (gherkin)
+```
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `structure.md`)
+- [x] Test tasks are included (T006 — BDD feature file)
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **`/running-retrospectives`** — New skill that batch-analyzes defect specs to identify spec-writing gaps (missing ACs, undertested boundaries, domain-specific gaps) and produces `.claude/steering/retrospective.md` with actionable learnings
+- **`/creating-issues`** — Upfront issue type classification: first question after gathering context asks whether this is a Bug or Enhancement/Feature via `AskUserQuestion`, then performs type-specific codebase investigation before the interview
+- **`/creating-issues`** — Enhancement path: explores existing specs and source code, adds "Current State" section to issue body between Background and Acceptance Criteria
+- **`/creating-issues`** — Bug path: searches codebase, traces code paths, forms root cause hypothesis, confirms with user, adds "Root Cause Analysis" section to issue body
 
 ### Changed
 
 - **`/writing-specs`** — Phase 1 now reads `retrospective.md` (when present) to apply defect-derived learnings when drafting acceptance criteria
+- **`/creating-issues`** — Interview questions now branch explicitly by issue type instead of adapting passively; workflow expanded from 6 steps to 8 steps (classification and investigation inserted as Steps 2–3); auto-mode references updated accordingly
 
 ## [2.4.0] - 2026-02-14
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Selects an issue (or presents a picker if no number is given), creates a linked 
 /creating-issues "add user authentication"
 ```
 
-Interviews you about the feature need, refines it into a groomed user story with Given/When/Then acceptance criteria, and creates a GitHub issue.
+Classifies the issue type (Bug or Enhancement/Feature), investigates the codebase for relevant context, then interviews you with type-specific questions. Produces a groomed issue with Given/When/Then acceptance criteria — enhancements include a "Current State" section from the investigation, bugs include a "Root Cause Analysis" section.
 
 ### Step 2: Write Specs
 

--- a/plugins/nmg-sdlc/.claude-plugin/plugin.json
+++ b/plugins/nmg-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nmg-sdlc",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Stack-agnostic BDD spec-driven development toolkit",
   "author": {
     "name": "Nunley Media Group"

--- a/plugins/nmg-sdlc/skills/creating-issues/SKILL.md
+++ b/plugins/nmg-sdlc/skills/creating-issues/SKILL.md
@@ -18,8 +18,8 @@ Interview the user to understand their need, then create a well-groomed GitHub i
 ## Automation Mode
 
 If the file `.claude/auto-mode` exists in the project directory:
-- Skip the interview (Step 2) — use the provided argument as the feature description. Read `.claude/steering/product.md` for product context. Generate 3–5 Given/When/Then acceptance criteria covering the happy path, one alternative path, and one error case.
-- Skip the review (Step 4) — do not call `AskUserQuestion`. Proceed directly to creating the issue.
+- Skip Steps 2, 3, and 4 (classification, investigation, and interview) — use the provided argument as the feature description. Read `.claude/steering/product.md` for product context. Generate 3–5 Given/When/Then acceptance criteria covering the happy path, one alternative path, and one error case.
+- Skip the review (Step 6) — do not call `AskUserQuestion`. Proceed directly to creating the issue.
 
 ## Workflow
 
@@ -33,14 +33,57 @@ Read `.claude/steering/product.md` if it exists to understand:
 - Feature prioritization (MoSCoW)
 - Existing user journeys
 
-### Step 2: Interview the User
+### Step 2: Classify Issue Type
 
-Ask questions adaptively to refine the need. If the user's initial description already covers a topic, skip it. Group related questions when natural — aim for 2–3 rounds, not 6 sequential questions.
+Use `AskUserQuestion` to ask the user what type of issue this is. This is always the first question after gathering context.
 
-Topics to cover (skip any already answered):
+Options:
+- **Bug** — "Something is broken or behaving incorrectly"
+- **Enhancement / Feature** — "New capability or improvement to existing behavior"
 
-1. **Who is the user?** What role or persona benefits from this?
-2. **What's the problem?** What pain point or gap exists today?
+> **Auto-mode**: This step is skipped. Classification is not needed when the interview is skipped.
+
+### Step 3: Investigate Codebase
+
+Based on the classification from Step 2, perform a targeted codebase investigation before the interview.
+
+#### If Enhancement / Feature
+
+1. **Explore existing specs**: Use `Glob` for `.claude/specs/*/requirements.md` and read any that relate to the area described by the user
+2. **Explore source code**: Use `Glob` and `Grep` to find files related to the enhancement area (e.g., the relevant SKILL.md, templates, hooks, or application code)
+3. **Summarize findings**: Produce a "Current State" summary capturing:
+   - What exists today (relevant code, patterns, specs)
+   - How the current implementation works
+   - What patterns should be preserved or built upon
+
+If no relevant code or specs are found, note that this appears to be a greenfield addition and move on.
+
+#### If Bug
+
+1. **Search for related code**: Use `Grep` to find code related to the bug description (error messages, function names, file patterns the user mentioned)
+2. **Trace code paths**: `Read` the relevant files and follow the logic through the affected paths
+3. **Form hypothesis**: Formulate a root cause hypothesis describing:
+   - What code is involved
+   - What the incorrect behavior or assumption is
+   - Why it manifests as the reported bug
+4. **Confirm with user**: Present the hypothesis via `AskUserQuestion`:
+   - "Yes, that matches"
+   - "Not quite — let me clarify"
+
+   If the user says "not quite", ask a follow-up clarifying question and revise the hypothesis.
+
+If investigation is inconclusive, note what is known and proceed with the user's description alone.
+
+> **Auto-mode**: This step is skipped.
+
+### Step 4: Interview the User
+
+Ask type-specific questions to refine the need. Skip any topics already answered by the user's initial description or the Step 3 investigation. Group related questions when natural — aim for 2–3 rounds, not 6 sequential questions.
+
+#### If Enhancement / Feature
+
+1. **Who benefits?** What role or persona benefits from this?
+2. **What's the pain point?** What gap or friction exists today?
 3. **What's the desired outcome?** What should happen when this is done?
 4. **What are the key acceptance criteria?** Guide toward Given/When/Then format:
    - "Given [some context], when [something happens], then [expected result]"
@@ -48,20 +91,18 @@ Topics to cover (skip any already answered):
 5. **What's in scope vs out of scope?** Set clear boundaries.
 6. **What's the priority?** Must / Should / Could / Won't (MoSCoW)
 
-Adapt questions based on the type of work:
-- **Feature**: Focus on user story, acceptance criteria, UI/UX needs
-- **Bug fix**: Focus on reproduction and diagnosis:
-  - "What are the exact steps to reproduce this bug?"
-  - "What do you expect to happen vs what actually happens?"
-  - "What environment does this occur in?" (OS, browser, version, configuration)
-  - "How often does it happen?" (always, intermittent, one-time)
-  - "Are there any error messages, stack traces, or log output?"
-  - "When did this start? Was there a recent change that might have caused it?"
-- **Enhancement**: Focus on current behavior, desired improvement, impact
+#### If Bug
 
-### Step 3: Synthesize into Issue Body
+1. **What are the exact reproduction steps?** Walk through the sequence that triggers the bug.
+2. **What's expected vs actual?** What should happen, and what actually happens?
+3. **What environment?** OS, browser, version, configuration, runtime.
+4. **How often?** Always, intermittent, one-time?
+5. **Any error output?** Error messages, stack traces, or log output?
+6. **When did this start?** Was there a recent change that might have caused it?
 
-Choose the appropriate template based on the type of work identified in Step 2.
+### Step 5: Synthesize into Issue Body
+
+Choose the appropriate template based on the issue type classified in Step 2.
 
 #### Feature / Enhancement Template
 
@@ -77,6 +118,12 @@ Draft the issue using this structure:
 ## Background
 
 [1-2 paragraphs: why this is needed, what problem it solves, any relevant context]
+
+## Current State
+
+[Summary from Step 3 investigation — what exists today, relevant code patterns,
+existing specs, and how the current implementation works. If no relevant code
+was found, state that this is a greenfield addition.]
 
 ## Acceptance Criteria
 
@@ -127,6 +174,14 @@ For bug fixes, use this structure instead:
 
 [1-2 sentence summary of the bug]
 
+## Root Cause Analysis
+
+[Hypothesis from Step 3 investigation — affected code paths, the incorrect
+assumption or logic, and triggering conditions. If investigation was
+inconclusive, state what is known and what needs further investigation.]
+
+**User Confirmed**: Yes / Partially / Investigation inconclusive
+
 ## Reproduction Steps
 
 1. [First step]
@@ -174,7 +229,7 @@ For bug fixes, use this structure instead:
 - [Related improvements not part of this fix]
 ```
 
-### Step 4: Present Draft for Review
+### Step 6: Present Draft for Review
 
 Show the complete issue draft to the user. Ask:
 - "Does this capture what you're looking for?"
@@ -183,7 +238,7 @@ Show the complete issue draft to the user. Ask:
 
 Iterate until the user approves.
 
-### Step 5: Create the Issue
+### Step 7: Create the Issue
 
 1. **Check labels**: Run `gh label list` to see existing labels
 2. **Create missing labels** if needed:
@@ -199,7 +254,7 @@ Iterate until the user approves.
    gh issue create --title "[concise, action-oriented title]" --body "[issue body]" --label "label1,label2"
    ```
 
-### Step 6: Output
+### Step 8: Output
 
 After creation, output:
 


### PR DESCRIPTION
## Summary

- Adds upfront bug/enhancement classification as the first interview question in the creating-issues skill, replacing the passive type-adaptation approach
- Introduces type-specific codebase investigation: current-state exploration for enhancements, root-cause analysis for bugs
- Adapts interview questions based on classified type and adds new issue body sections (Current State, Root Cause Analysis)

## Acceptance Criteria

From `.claude/specs/21-upfront-issue-type-classification/requirements.md`:

- [ ] AC1: First interview question classifies issue as bug or enhancement/feature
- [ ] AC2: Enhancement path explores existing specs and source code, includes "Current State" summary
- [ ] AC3: Bug path searches codebase, traces code paths, forms root cause hypothesis, confirms with user
- [ ] AC4: Automation mode behavior is unchanged
- [ ] AC5: Remaining interview questions adapt based on classified type
- [ ] AC6: Enhancement issues include "Current State" section in body
- [ ] AC7: Bug issues include "Root Cause Analysis" section in body

## Test Plan

From `.claude/specs/21-upfront-issue-type-classification/tasks.md`:

- [ ] BDD feature file covers all 7 acceptance criteria with valid Gherkin scenarios
- [ ] Scenarios are independent and include happy path, alternative paths, and edge cases

## Specs

- Requirements: `.claude/specs/21-upfront-issue-type-classification/requirements.md`
- Design: `.claude/specs/21-upfront-issue-type-classification/design.md`
- Tasks: `.claude/specs/21-upfront-issue-type-classification/tasks.md`
- Feature: `.claude/specs/21-upfront-issue-type-classification/feature.gherkin`

Closes Nunley-Media-Group/nmg-sdlc#19