### PR TITLE
feat: add /migrating-projects skill to update project files to latest templates (#25)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "nmg-sdlc",
       "source": "./plugins/nmg-sdlc",
       "description": "BDD spec-driven development: issue creation, specifications, verification, and PR workflows.",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "keywords": ["sdlc", "bdd", "gherkin", "specifications", "github-issues"]
     }
   ]

--- a/.claude/specs/25-add-migration-skill/design.md
+++ b/.claude/specs/25-add-migration-skill/design.md
@@ -1,0 +1,261 @@
+# Design: Add Migration Skill
+
+**Issue**: #25
+**Date**: 2026-02-15
+**Status**: Draft
+**Author**: Claude
+
+---
+
+## Overview
+
+The migration skill (`/migrating-projects`) is a prompt-based SKILL.md workflow that brings existing project files up to current plugin standards. Like all nmg-sdlc skills, it is a Markdown document that guides Claude through a structured process — no runtime code is required.
+
+The skill follows a **scan → analyze → present → approve → apply** pattern. It reads the latest templates at runtime from the plugin's template directories, compares their heading structure against existing project files, identifies missing sections, and presents proposed additions for user review before modifying any files.
+
+The core algorithm is **heading-based section diffing for Markdown files** and **key-level diffing for JSON configs**. The skill never rewrites existing content — it only inserts missing sections at the correct position with template placeholder content.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+/migrating-projects (SKILL.md)
+    │
+    ├── Step 1: Locate Templates
+    │   ├── Steering templates:  setting-up-steering/templates/*.md
+    │   ├── Spec templates:      writing-specs/templates/*.md
+    │   └── Config template:     openclaw/scripts/sdlc-config.example.json
+    │
+    ├── Step 2: Scan Project Files
+    │   ├── Steering docs:       .claude/steering/*.md
+    │   ├── Spec directories:    .claude/specs/*/{requirements,design,tasks}.md
+    │   └── Config:              sdlc-config.json (project root)
+    │
+    ├── Step 3: Analyze Differences
+    │   ├── Markdown files → Heading-based section diffing (## level)
+    │   └── JSON configs   → Key-level diffing (root + steps)
+    │
+    ├── Step 4: Present Changes (Interactive Review Gate)
+    │   └── Per-file summary of proposed additions
+    │
+    ├── Step 5: Apply Changes
+    │   └── Insert missing sections / merge missing keys
+    │
+    └── Step 6: OpenClaw Skill Version Check
+        └── Compare ~/.openclaw/skills/running-sdlc/ against source
+```
+
+### Data Flow
+
+```
+1. Skill resolves template directory paths from the installed plugin
+2. Glob finds existing project files (steering docs, specs, config)
+3. Read loads each template and its corresponding project file
+4. Claude parses ## headings from both and identifies missing sections
+5. For each missing section, Claude extracts the template content between headings
+6. Proposed changes are presented as a per-file summary
+7. User approves or rejects
+8. If approved, Claude uses Edit to insert missing sections at correct positions
+9. Summary report is output
+```
+
+---
+
+## API / Interface Changes
+
+### New Skill
+
+| Skill | Location | Purpose |
+|-------|----------|---------|
+| `/migrating-projects` | `plugins/nmg-sdlc/skills/migrating-projects/SKILL.md` | Migrate project files to latest template standards |
+
+### Skill Invocation
+
+**Input:** No arguments required. The skill operates on the current project directory.
+
+**Output:** Summary report listing all files analyzed and changes made.
+
+**Errors:**
+
+| Condition | Behavior |
+|-----------|----------|
+| No `.claude/steering/` directory found | Skip steering migration, report "no steering docs found" |
+| No `.claude/specs/` directory found | Skip spec migration, report "no specs found" |
+| No `sdlc-config.json` found | Skip config migration, report "no config found" |
+| Template directories not resolvable | Error: "Cannot find plugin templates — is nmg-sdlc installed?" |
+| User rejects changes | Abort with no modifications |
+
+---
+
+## Database / Storage Changes
+
+No database or schema changes. This skill operates on local Markdown and JSON files only.
+
+---
+
+## State Management
+
+No persistent state. The skill is stateless — it performs a full comparison on every invocation. There is no version tracking or migration history.
+
+---
+
+## UI Components
+
+Not applicable — this is a CLI skill with text-based interaction.
+
+---
+
+## Detailed Design
+
+### Section Diffing Algorithm (Markdown)
+
+The core migration logic for Markdown files uses **heading-level comparison**:
+
+1. **Parse headings** — Extract all `##`-level headings from both the template and the existing file
+2. **Identify missing** — Find headings present in the template but absent in the existing file
+3. **Determine insertion point** — For each missing heading, find the preceding heading (in template order) that exists in the project file; the missing section inserts after that section's content
+4. **Extract template content** — The content for each missing section is the text between its heading and the next heading in the template (placeholder guidance, tables, etc.)
+
+**Heading extraction approach:**
+```
+Template headings:  [## Mission, ## Target Users, ## Core Value, ## Product Principles, ## Success Metrics]
+Existing headings:  [## Mission, ## Target Users, ## Success Metrics]
+Missing:            [## Core Value, ## Product Principles]
+```
+
+**Insertion logic:**
+- `## Core Value` → insert after `## Target Users` section content (predecessor in template order)
+- `## Product Principles` → insert after `## Core Value` section content (which was just inserted)
+
+**Template content boundaries:**
+- Each template file contains the template inside a Markdown code block (` ```markdown ... ``` `)
+- The skill must parse the **content inside the code block**, not the surrounding instructional text
+- For templates with two variants (feature + defect), the feature variant is the first code block and the defect variant follows after a `# Defect` heading
+
+### Spec Variant Detection
+
+For spec files (`requirements.md`, `design.md`, `tasks.md`), the skill must determine whether to compare against the feature or defect template variant:
+
+1. **Content-based detection (primary):** Check the first heading in the existing file:
+   - `# Requirements:` or `# Design:` or `# Tasks:` → feature variant
+   - `# Defect Report:` or `# Root Cause Analysis:` → defect variant
+2. **No fallback to gh CLI needed** — the file heading is definitive since `/writing-specs` always uses these heading patterns
+
+### JSON Config Diffing
+
+For `sdlc-config.json`, the approach differs from Markdown:
+
+1. **Read both files** — Parse the project's `sdlc-config.json` and the template `sdlc-config.example.json`
+2. **Compare at root level** — Identify top-level keys in the template that are absent from the project config
+3. **Compare at steps level** — Identify step keys (`steps.*`) in the template absent from the project config
+4. **Merge strategy:**
+   - Missing root keys → add with template default values
+   - Missing step keys → add with template default values
+   - Existing keys → preserve user values (never overwrite)
+   - New keys within existing steps (e.g., a new `skill` field added to an existing step) → add with template default
+
+### OpenClaw Skill Version Check
+
+1. **Read installed files** at `~/.openclaw/skills/running-sdlc/`
+2. **Read source files** at `openclaw/skills/running-sdlc/` in the marketplace clone
+3. **Compare content** — If any file differs, warn the user and suggest running `/installing-openclaw-skill`
+4. **If not installed** — Skip with a note that OpenClaw skill is not installed locally
+
+### Gherkin Files (feature.gherkin)
+
+Gherkin files in `.claude/specs/*/feature.gherkin` are **excluded from section migration**. Unlike Markdown specs, Gherkin files contain project-specific scenarios that are not structurally comparable to the template. The template is a placeholder guide, not a structural standard. Migration of Gherkin files would risk corrupting hand-written test scenarios.
+
+### Template Resolution
+
+Templates are resolved at runtime from the installed plugin directory. The skill uses `Glob` to locate:
+
+```
+plugins/nmg-sdlc/skills/setting-up-steering/templates/*.md  → steering templates
+plugins/nmg-sdlc/skills/writing-specs/templates/*.md         → spec templates
+openclaw/scripts/sdlc-config.example.json                    → config template
+```
+
+The skill uses `${CLAUDE_PLUGIN_ROOT}` or resolves paths relative to the skill's own location within the plugin directory tree.
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Full file regeneration** | Re-run `/setting-up-steering` and `/writing-specs` to regenerate files from scratch | Simple, always produces latest format | Destroys all user-written content; requires re-filling every section | Rejected — violates content preservation requirement |
+| **B: Heading-based section diffing** | Parse headings, identify missing sections, insert at correct position | Preserves user content; self-updating; lightweight | Requires careful heading parsing; can't detect renamed sections | **Selected** — best balance of safety and effectiveness |
+| **C: Line-by-line diff/merge** | Full text diff between template and existing file | Catches every difference including within sections | Would flag all user customizations as "differences"; high false positive rate | Rejected — too noisy; would try to overwrite user content |
+| **D: Version-tagged migrations** | Track template version in a metadata field, apply incremental patches per version | Precise; handles renames and reorganizations | Requires maintaining migration scripts per version; not self-updating | Rejected — violates self-updating design principle |
+
+---
+
+## Security Considerations
+
+- [x] **Authentication**: No external auth required; operates on local files only
+- [x] **Authorization**: Interactive review gate prevents unauthorized file modifications
+- [x] **Input Validation**: Template paths resolved from known plugin directories; no user-supplied paths
+- [x] **Data Sanitization**: Existing file content is never reprocessed or re-interpreted
+- [x] **Sensitive Data**: No secrets or credentials involved; operates on Markdown and JSON config files
+
+---
+
+## Performance Considerations
+
+- [x] **Caching**: Not needed — single-pass analysis within one skill invocation
+- [x] **Pagination**: Not applicable
+- [x] **Lazy Loading**: Templates loaded only for file types that exist in the project
+- [x] **Indexing**: Not applicable
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Section diffing | BDD | Missing sections detected and inserted correctly |
+| Content preservation | BDD | Existing content unchanged after migration |
+| Variant detection | BDD | Feature vs defect templates applied correctly |
+| JSON config diffing | BDD | Missing keys merged, existing values preserved |
+| Edge cases | BDD | Already up-to-date, missing files, no project files |
+| OpenClaw check | BDD | Outdated skill detected and reported |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Heading parsing misidentifies section boundaries | Low | Medium | Use `## ` prefix matching (standard ATX headings); validate against known template headings |
+| Template code block parsing extracts wrong content | Low | High | Templates follow a consistent pattern (instructional text + single code block per variant); test with all current templates |
+| Inserted sections break document flow | Low | Medium | Insert with proper `---` separators matching template style; user reviews before apply |
+| JSON merge overwrites user-customized step values | Low | High | Only add missing keys; never modify existing key values |
+| Renamed template sections cause false "missing" | Low | Low | Acceptable trade-off — skill inserts the new-name section; user can manually remove the old-name section during review |
+
+---
+
+## Open Questions
+
+- [x] Should `feature.gherkin` files be migrated? — **No**, they contain project-specific scenarios not structurally comparable to the template
+- [x] How should template code blocks be parsed? — Extract content between ` ```markdown ` and ` ``` ` delimiters; first block is feature variant, content after `# Defect` heading is defect variant
+- [x] What about `### ` (H3) level headings? — Only compare at `## ` level for section presence; H3 subheadings are part of their parent section's content and get included when a missing `## ` section is inserted
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Architecture follows existing project patterns (per `structure.md`) — SKILL.md in `skills/migrating-projects/`
+- [x] All API/interface changes documented with schemas — skill input/output/errors defined
+- [x] Database/storage changes planned with migrations — N/A (no database)
+- [x] State management approach is clear — stateless, full comparison each run
+- [x] UI components and hierarchy defined — N/A (CLI skill)
+- [x] Security considerations addressed — interactive gate, no auth needed
+- [x] Performance impact analyzed — single-pass, no external APIs
+- [x] Testing strategy defined — BDD scenarios per acceptance criterion
+- [x] Alternatives were considered and documented — 4 options evaluated
+- [x] Risks identified with mitigations — 5 risks documented

--- a/.claude/specs/25-add-migration-skill/feature.gherkin
+++ b/.claude/specs/25-add-migration-skill/feature.gherkin
@@ -1,0 +1,103 @@
+# File: .claude/specs/25-add-migration-skill/feature.gherkin
+#
+# Generated from: .claude/specs/25-add-migration-skill/requirements.md
+# Issue: #25
+
+Feature: Project Migration Skill
+  As a developer using the nmg-sdlc plugin
+  I want a migration skill that updates my project's files to latest standards
+  So that I benefit from new template sections without manually diffing templates
+
+  # --- Happy Path ---
+
+  Scenario: Steering doc migration adds missing sections
+    Given a project with a "product.md" steering doc missing the "Product Principles" section
+    And the latest "setting-up-steering" template includes a "Product Principles" section
+    When I run "/migrating-projects"
+    Then the "Product Principles" section is identified as missing
+    And the section is inserted after "Core Value Proposition" with template placeholder content
+    And all existing user-written content in "product.md" remains unchanged
+
+  Scenario: Spec migration adds missing sections
+    Given a project with a "requirements.md" spec missing "Non-Functional Requirements" and "UI/UX Requirements"
+    And the latest "writing-specs" template includes both sections
+    When I run "/migrating-projects"
+    Then both missing sections are identified
+    And each section is inserted at the correct position per template order
+    And all existing acceptance criteria and functional requirements remain unchanged
+
+  Scenario: User content is preserved during migration
+    Given a "tech.md" steering doc with a filled-in Technology Stack table listing project-specific technologies
+    And the latest template includes a new "Claude Code Resource Development" section
+    When the migration adds the new section
+    Then the Technology Stack table content is identical before and after migration
+    And no existing content is modified or reordered
+
+  # --- Alternative Paths ---
+
+  Scenario: Interactive review before apply
+    Given the migration analysis has identified missing sections in 3 files
+    When the analysis is complete
+    Then a per-file summary of proposed additions is presented
+    And I can review each proposed change
+    And no files are modified until I approve the migration
+
+  Scenario: User rejects migration
+    Given the migration analysis has identified proposed changes
+    When I reject the migration at the review gate
+    Then no files are modified
+    And the skill reports that migration was cancelled
+
+  Scenario: Self-updating template detection
+    Given the plugin's "requirements.md" template has been updated with a new "Risk Assessment" section
+    And the migration skill has not been modified
+    When I run "/migrating-projects"
+    Then the new "Risk Assessment" section is detected as missing from existing specs
+    And the skill proposes adding it without any code changes to the skill itself
+
+  Scenario: OpenClaw config migration merges missing keys
+    Given a project with an "sdlc-config.json" missing the "cleanup" key and a new "merge" step
+    And the latest "sdlc-config.example.json" template includes both
+    When I run "/migrating-projects"
+    Then the "cleanup" key is added with template default values
+    And the "merge" step is added to the "steps" object
+    And existing user values for "projectPath" and "discordChannelId" are preserved
+
+  Scenario: OpenClaw skill version check warns when outdated
+    Given the OpenClaw "running-sdlc" skill is installed at "~/.openclaw/skills/running-sdlc/"
+    And the installed SKILL.md differs from the source in the marketplace clone
+    When I run "/migrating-projects"
+    Then a warning is displayed indicating the installed skill is outdated
+    And the warning suggests running "/installing-openclaw-skill" to update
+
+  # --- Edge Cases ---
+
+  Scenario: All files already up to date
+    Given all steering docs match the latest template structure
+    And all spec files match the latest template structure
+    And the "sdlc-config.json" has all current keys
+    When I run "/migrating-projects"
+    Then the skill reports "everything is up to date"
+    And no files are modified
+
+  Scenario: Missing project files are skipped
+    Given a project with "product.md" but no "structure.md" in ".claude/steering/"
+    And no ".claude/specs/" directory exists
+    When I run "/migrating-projects"
+    Then only "product.md" is analyzed for migration
+    And missing files are not created
+    And the summary notes that "/setting-up-steering" or "/writing-specs" can create missing files
+
+  Scenario: Defect spec variant is correctly detected
+    Given a spec directory with a "requirements.md" starting with "# Defect Report:"
+    And the latest defect template variant includes a new section
+    When I run "/migrating-projects"
+    Then the defect template variant is used for comparison instead of the feature variant
+    And the missing section from the defect variant is proposed for insertion
+
+  Scenario: Feature spec variant is correctly detected
+    Given a spec directory with a "requirements.md" starting with "# Requirements:"
+    And the latest feature template includes a new section
+    When I run "/migrating-projects"
+    Then the feature template variant is used for comparison
+    And the missing section from the feature variant is proposed for insertion

--- a/.claude/specs/25-add-migration-skill/requirements.md
+++ b/.claude/specs/25-add-migration-skill/requirements.md
@@ -1,0 +1,281 @@
+# Requirements: Add Migration Skill
+
+**Issue**: #25
+**Date**: 2026-02-15
+**Status**: Draft
+**Author**: Claude
+
+---
+
+## User Story
+
+**As a** developer using the nmg-sdlc plugin
+**I want** a migration skill that updates my project's existing specs, steering docs, and configs to the latest plugin standards
+**So that** I benefit from new template sections, improved structures, and evolving best practices without manually diffing templates
+
+---
+
+## Background
+
+The nmg-sdlc plugin evolves over time — new sections get added to spec templates (e.g., NFRs, UI/UX requirements, Related Spec field for defects), steering doc templates gain new guidance areas, and structural conventions change. Projects that adopted the plugin at an earlier version retain their original file formats with no mechanism to bring them up to current standards.
+
+The migration skill should be **self-updating by design**: it reads the latest templates at runtime from the plugin's template directories, so when templates change in a new plugin version, the migration skill automatically knows the new standards without needing its own code updated.
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Steering Doc Migration — Happy Path
+
+**Given** a project with steering docs (product.md, tech.md, structure.md) created by an older version of `/setting-up-steering`
+**When** I run `/migrating-projects`
+**Then** missing sections are identified in each steering doc and merged in while preserving all existing user-written content
+
+**Example**:
+- Given: A `product.md` missing the `## Product Principles` section that was added in a later template version
+- When: `/migrating-projects` is run
+- Then: The `## Product Principles` section is inserted at the correct location with placeholder guidance, and all existing content remains unchanged
+
+### AC2: Spec Migration — Happy Path
+
+**Given** a project with specs (requirements.md, design.md, tasks.md, feature.gherkin) created by an older version of `/writing-specs`
+**When** I run `/migrating-projects`
+**Then** missing sections are identified in each spec file and merged in while preserving all existing content
+
+**Example**:
+- Given: A `requirements.md` missing the `## Non-Functional Requirements` and `## UI/UX Requirements` sections
+- When: `/migrating-projects` is run
+- Then: Both sections are inserted at the correct location with template defaults, and all existing acceptance criteria and functional requirements remain unchanged
+
+### AC3: User Content Preservation
+
+**Given** a steering doc with user-customized content (e.g., mission statement, target users, tech stack details)
+**When** the migration adds new template sections
+**Then** all existing user-written content remains unchanged and new sections are inserted at the appropriate location with placeholder guidance
+
+**Example**:
+- Given: A `tech.md` with a filled-in `## Technology Stack` table listing React, PostgreSQL, etc.
+- When: Migration adds a missing `## Claude Code Resource Development` section
+- Then: The Technology Stack table content is byte-for-byte identical before and after migration
+
+### AC4: Interactive Review Before Apply
+
+**Given** proposed changes to one or more project files
+**When** the migration analysis is complete
+**Then** all proposed changes are presented to the user for review before any files are modified
+**And** the user can approve or reject the migration
+
+### AC5: Self-Updating via Runtime Template Reading
+
+**Given** the plugin's templates have been updated in a new version (e.g., a new section added to requirements.md template)
+**When** I run `/migrating-projects`
+**Then** the skill detects the new template sections automatically without needing the migration skill itself to be updated
+
+### AC6: OpenClaw Config Migration
+
+**Given** a project with an `sdlc-config.json` created by an older version of `/generating-openclaw-config`
+**When** I run `/migrating-projects`
+**Then** missing config keys (e.g., new steps, changed defaults) are identified and merged into the existing config while preserving user-customized values (paths, timeouts, Discord channel ID)
+
+### AC7: OpenClaw Skill Version Check
+
+**Given** the OpenClaw `running-sdlc` skill is installed at `~/.openclaw/skills/running-sdlc/`
+**When** I run `/migrating-projects`
+**Then** the installed skill files are compared against the source in the marketplace clone
+**And** a warning is displayed if they differ, suggesting the user run `/installing-openclaw-skill` to update
+
+### AC8: Already Up-to-Date — No Changes
+
+**Given** all project files already match the latest template structure
+**When** I run `/migrating-projects`
+**Then** the skill reports that everything is up to date and makes no file modifications
+
+### AC9: Missing Files Are Skipped
+
+**Given** a project that has only some steering docs (e.g., `product.md` exists but `structure.md` does not)
+**When** I run `/migrating-projects`
+**Then** only existing files are migrated
+**And** missing files are not created (the user is directed to use `/setting-up-steering` or `/writing-specs` instead)
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: Project Migration Skill
+  As a developer using the nmg-sdlc plugin
+  I want a migration skill that updates my project's files to latest standards
+  So that I benefit from new template sections without manually diffing templates
+
+  Scenario: Steering doc migration — happy path
+    Given a project with steering docs created by an older plugin version
+    When I run "/migrating-projects"
+    Then missing sections are identified and merged into each steering doc
+    And all existing user-written content is preserved
+
+  Scenario: Spec migration — happy path
+    Given a project with specs created by an older plugin version
+    When I run "/migrating-projects"
+    Then missing sections are identified and merged into each spec file
+    And all existing content is preserved
+
+  Scenario: User content preservation
+    Given a steering doc with user-customized content
+    When the migration adds new template sections
+    Then all existing user-written content remains unchanged
+
+  Scenario: Interactive review before apply
+    Given proposed changes to project files
+    When the migration analysis is complete
+    Then all proposed changes are presented for user review
+    And the user can approve or reject the migration
+
+  Scenario: Self-updating via runtime template reading
+    Given the plugin templates have been updated in a new version
+    When I run "/migrating-projects"
+    Then the skill detects new template sections automatically
+
+  Scenario: OpenClaw config migration
+    Given a project with an sdlc-config.json from an older version
+    When I run "/migrating-projects"
+    Then missing config keys are merged while preserving user-customized values
+
+  Scenario: OpenClaw skill version check
+    Given the OpenClaw running-sdlc skill is installed locally
+    When I run "/migrating-projects"
+    Then installed skill files are compared against the source
+    And a warning is displayed if they differ
+
+  Scenario: Already up-to-date — no changes
+    Given all project files match the latest template structure
+    When I run "/migrating-projects"
+    Then the skill reports everything is up to date
+
+  Scenario: Missing files are skipped
+    Given a project with only some steering docs present
+    When I run "/migrating-projects"
+    Then only existing files are migrated
+    And missing files are not created
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | Scan `.claude/steering/` and compare each doc against the latest templates from `setting-up-steering/templates/` | Must | |
+| FR2 | Scan `.claude/specs/*/` and compare each spec file against the latest templates from `writing-specs/templates/` | Must | |
+| FR3 | Identify missing sections by comparing template headings/structure against existing file headings | Must | Markdown heading-based comparison |
+| FR4 | Merge missing sections into existing files at the correct location, preserving all user content | Must | Insert at position matching template order |
+| FR5 | Present a per-file summary of proposed changes for interactive review before applying | Must | |
+| FR6 | Read templates at runtime from the plugin's template directories (never hardcode template content) | Must | Self-updating design |
+| FR7 | Output a summary report of all changes made after migration completes | Should | |
+| FR8 | Handle both feature and defect spec variants when migrating specs | Should | Detect variant from existing content |
+| FR9 | Detect spec type (feature vs defect) from existing content or issue labels to apply the correct template | Should | Check for `# Defect Report:` heading or `bug` label |
+| FR10 | Skip files that are already up to date (no unnecessary modifications) | Should | |
+| FR11 | Scan project root for `sdlc-config.json` and compare against `openclaw/scripts/sdlc-config.example.json` | Must | JSON key-level diffing |
+| FR12 | Merge missing config keys and new step definitions while preserving user-set values (projectPath, pluginsPath, discordChannelId, custom timeouts) | Must | |
+| FR13 | Compare installed OpenClaw skill (`~/.openclaw/skills/running-sdlc/`) against source in marketplace clone and warn if outdated | Should | Suggest `/installing-openclaw-skill` |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Complete migration analysis within a single skill invocation; no external API calls beyond `gh` for label checks |
+| **Security** | Never modify files without explicit user approval; no secrets or credentials in migration output |
+| **Reliability** | If migration fails mid-apply, already-written files remain valid (each file is written atomically) |
+| **Platforms** | Must work on macOS, Windows, and Linux per tech.md cross-platform requirements |
+
+---
+
+## UI/UX Requirements
+
+| Element | Requirement |
+|---------|-------------|
+| **Interaction** | Interactive review gate before applying changes; user approves or rejects |
+| **Loading States** | Display progress as each file category (steering, specs, config) is analyzed |
+| **Error States** | Clear error message if template directories cannot be found |
+| **Empty States** | Friendly message when everything is already up to date |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| Project directory | Path | Must contain `.claude/` directory | Yes |
+| Template directories | Paths | Must exist within installed plugin | Yes (resolved at runtime) |
+| sdlc-config.json | JSON file | Valid JSON | No (skipped if absent) |
+
+### Output Data
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Migration report | Markdown text | Per-file summary of sections added |
+| Modified files | Markdown/JSON files | Updated project files with new sections merged |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- [ ] `setting-up-steering/templates/` — steering doc templates (source of truth)
+- [ ] `writing-specs/templates/` — spec file templates (source of truth)
+- [ ] `openclaw/scripts/sdlc-config.example.json` — OpenClaw config template
+
+### External Dependencies
+- [ ] `gh` CLI — for checking issue labels when detecting spec type (feature vs defect)
+
+### Blocked By
+- None
+
+---
+
+## Out of Scope
+
+- **Auto-mode support** — this skill is always interactive; migration is sensitive enough to require human review
+- **Version tracking / incremental migrations** — always migrates to current standards in one shot
+- **Migrating CLAUDE.md or hook configurations** — those are project-owned, not template-driven
+- **Creating missing files** — the skill updates existing files, not bootstrapping new ones (use `/setting-up-steering` or `/writing-specs` for that)
+- **Modifying user-written content** — only adds missing sections; never rewrites existing content
+- **Auto-updating the OpenClaw skill** — the migration skill warns if outdated; use `/installing-openclaw-skill` to update
+- **Regenerating `sdlc-config.json` from scratch** — the skill merges new keys, not replaces the file
+- **Migrating `retrospective.md`** — generated by `/running-retrospectives` and not template-driven in the same way
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Content preservation | Zero user content lost during migration | Diff before/after shows only additions |
+| Template coverage | All template sections detected and mergeable | Compare template section list against migration output |
+| Self-updating accuracy | Skill detects new sections in updated templates without code changes | Test with a template that has an added section |
+
+---
+
+## Open Questions
+
+- [x] Should `retrospective.md` be included in migration scope? — **No**, it is generated output from `/running-retrospectives`, not a user-authored doc from a template
+- [x] How should defect vs feature spec variants be detected? — Check for `# Defect Report:` heading in existing `requirements.md` or fall back to `gh issue view` label check
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases and error states are specified (AC8, AC9)
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented (or resolved)

--- a/.claude/specs/25-add-migration-skill/tasks.md
+++ b/.claude/specs/25-add-migration-skill/tasks.md
@@ -1,0 +1,140 @@
+# Tasks: Add Migration Skill
+
+**Issue**: #25
+**Date**: 2026-02-15
+**Status**: Planning
+**Author**: Claude
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 1 | [ ] |
+| Backend (Skill Implementation) | 1 | [ ] |
+| Integration | 3 | [ ] |
+| Testing | 1 | [ ] |
+| **Total** | **6** | |
+
+---
+
+## Phase 1: Setup
+
+### T001: Create migrating-projects skill directory
+
+**File(s)**: `plugins/nmg-sdlc/skills/migrating-projects/SKILL.md`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] Directory `plugins/nmg-sdlc/skills/migrating-projects/` exists
+- [ ] `SKILL.md` file is created (content comes in T002)
+
+---
+
+## Phase 2: Skill Implementation
+
+### T002: Write the SKILL.md for `/migrating-projects`
+
+**File(s)**: `plugins/nmg-sdlc/skills/migrating-projects/SKILL.md`
+**Type**: Create
+**Depends**: T001
+**Acceptance**:
+- [ ] SKILL.md follows the standard skill structure (title, When to Use, Workflow steps, Integration with SDLC Workflow)
+- [ ] Skill is not user-invocable with arguments (no `$ARGUMENTS` — operates on current project)
+- [ ] Step 1: Resolve template paths — locate `setting-up-steering/templates/`, `writing-specs/templates/`, `openclaw/scripts/sdlc-config.example.json` from the installed plugin
+- [ ] Step 2: Scan project files — use `Glob` to find steering docs, spec files, and `sdlc-config.json`
+- [ ] Step 3: Analyze steering docs — read each template, extract headings from the code block, compare against existing steering docs, identify missing `##`-level sections
+- [ ] Step 4: Analyze spec files — for each spec directory, detect variant (feature vs defect) by checking first `#` heading, compare against correct template variant, identify missing `##`-level sections
+- [ ] Step 5: Analyze OpenClaw config — read `sdlc-config.json` and template, identify missing keys at root and `steps` level
+- [ ] Step 6: Check OpenClaw skill version — compare `~/.openclaw/skills/running-sdlc/` against source in marketplace clone
+- [ ] Step 7: Present findings — display per-file summary of proposed additions for interactive review
+- [ ] Step 8: Apply changes — if approved, use `Edit` to insert missing sections at correct positions; for JSON config, merge missing keys
+- [ ] Step 9: Output summary — report all changes made
+- [ ] No auto-mode support (skill is always interactive)
+- [ ] Heading extraction instructions explain how to parse template code blocks (content between ` ```markdown ` and ` ``` `)
+- [ ] Insertion logic instructions explain positioning (insert after the predecessor section in template order)
+- [ ] Variant detection instructions explain how to identify feature vs defect specs
+- [ ] JSON merge instructions explain key-level diffing (add missing keys, never overwrite existing values)
+- [ ] `feature.gherkin` files explicitly excluded from migration
+- [ ] Includes handling for "already up to date" case
+- [ ] Includes handling for missing project files (skip, don't create)
+- [ ] Allowed tools include `Read`, `Glob`, `Grep`, `Edit`, `Bash(gh:*)`, `AskUserQuestion`
+
+**Notes**: This is the core deliverable. The SKILL.md must contain clear, unambiguous instructions for Claude to execute the heading-based section diffing algorithm. Include concrete examples of heading extraction, comparison, and insertion. The skill must be self-updating — all template knowledge comes from reading files at runtime, never hardcoded.
+
+---
+
+## Phase 3: Integration
+
+### T003: Update README.md with new skill
+
+**File(s)**: `README.md`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `/migrating-projects` added to the SDLC Skills table in the Skills Reference section
+- [ ] Description matches the skill purpose: "Update project specs, steering docs, and configs to latest template standards"
+- [ ] Positioned logically in the table (after `/setting-up-steering` since it's a maintenance skill)
+
+### T004: Update CHANGELOG.md
+
+**File(s)**: `CHANGELOG.md`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] Entry added under `[Unreleased]` → `### Added` section
+- [ ] Entry describes the new `/migrating-projects` skill with key capabilities
+- [ ] Follows existing changelog style (bold skill name, em-dash, description)
+
+### T005: Bump plugin version (2.6.0 → 2.7.0)
+
+**File(s)**: `plugins/nmg-sdlc/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `plugins/nmg-sdlc/.claude-plugin/plugin.json` → `"version"` updated to `"2.7.0"`
+- [ ] `.claude-plugin/marketplace.json` → plugin entry `"version"` updated to `"2.7.0"`
+- [ ] `metadata.version` in `marketplace.json` is NOT changed (it's the collection version)
+
+---
+
+## Phase 4: BDD Testing
+
+### T006: Create BDD feature file
+
+**File(s)**: `.claude/specs/25-add-migration-skill/feature.gherkin`
+**Type**: Create
+**Depends**: T002
+**Acceptance**:
+- [ ] All 9 acceptance criteria from requirements.md have corresponding scenarios
+- [ ] Uses Given/When/Then format
+- [ ] Scenarios are independent and self-contained
+- [ ] Includes happy paths, edge cases, and error handling
+- [ ] Valid Gherkin syntax
+
+---
+
+## Dependency Graph
+
+```
+T001 ──▶ T002 ──┬──▶ T003
+                ├──▶ T004
+                ├──▶ T005
+                └──▶ T006
+```
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `structure.md`)
+- [x] Test tasks are included (T006)
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **`/migrating-projects`** — New skill that updates existing project specs, steering docs, and OpenClaw configs to latest template standards by diffing headings against current templates and merging missing sections while preserving all user content
 - **`/running-retrospectives`** — New skill that batch-analyzes defect specs to identify spec-writing gaps (missing ACs, undertested boundaries, domain-specific gaps) and produces `.claude/steering/retrospective.md` with actionable learnings
 - **`/creating-issues`** — Upfront issue type classification: first question after gathering context asks whether this is a Bug or Enhancement/Feature via `AskUserQuestion`, then performs type-specific codebase investigation before the interview
 - **`/creating-issues`** — Enhancement path: explores existing specs and source code, adds "Current State" section to issue body between Background and Acceptance Criteria

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ The plugin provides the **process**. Your project provides **specifics** via ste
 | `/creating-prs #N` | Create a pull request with spec-driven summary, linking GitHub issue and spec documents |
 | `/running-retrospectives` | Batch-analyze defect specs to identify spec-writing gaps and produce `.claude/steering/retrospective.md` with actionable learnings |
 | `/setting-up-steering` | Analyze codebase and generate steering documents (product, tech, structure). Run once per project |
+| `/migrating-projects` | Update project specs, steering docs, and configs to latest template standards |
 | `/installing-openclaw-skill` | Copy the OpenClaw running-sdlc skill from the marketplace clone to `~/.openclaw/skills/` and restart the gateway |
 | `/generating-openclaw-config` | Generate an `sdlc-config.json` for the SDLC runner, with project path auto-detected and written to the project root |
 

--- a/plugins/nmg-sdlc/.claude-plugin/plugin.json
+++ b/plugins/nmg-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nmg-sdlc",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Stack-agnostic BDD spec-driven development toolkit",
   "author": {
     "name": "Nunley Media Group"

--- a/plugins/nmg-sdlc/skills/migrating-projects/SKILL.md
+++ b/plugins/nmg-sdlc/skills/migrating-projects/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: migrating-projects
+description: "Update project specs, steering docs, and configs to latest template standards."
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Edit, Bash(gh:*), AskUserQuestion
+---
+
+# Migrating Projects
+
+Update existing project files (steering docs, specs, OpenClaw configs) to the latest template standards by diffing headings against current templates and merging missing sections — preserving all user content.
+
+**This skill is self-updating.** It reads templates at runtime, so when templates gain new sections, this skill detects them automatically without any code changes.
+
+## When to Use
+
+- After updating the nmg-sdlc plugin (new template sections may exist)
+- When steering docs or specs were created with an older plugin version
+- To check whether project files are up to date with current standards
+
+## What Gets Analyzed
+
+```
+.claude/steering/*.md          — Steering docs (product, tech, structure)
+.claude/specs/*/requirements.md — Spec requirements (feature + defect variants)
+.claude/specs/*/design.md      — Spec designs (feature + defect variants)
+.claude/specs/*/tasks.md       — Spec task breakdowns (feature + defect variants)
+sdlc-config.json               — OpenClaw runner config (JSON key merge)
+~/.openclaw/skills/running-sdlc/ — OpenClaw skill version check
+```
+
+**NOT analyzed:** `feature.gherkin` files (generated, not templated).
+
+---
+
+## Workflow
+
+### Step 1: Resolve Template Paths
+
+Locate the template directories from the installed plugin. Use this skill's own file path to resolve paths relative to the plugin root:
+
+- **Steering templates:** `plugins/nmg-sdlc/skills/setting-up-steering/templates/*.md`
+  - `product.md`, `tech.md`, `structure.md`
+- **Spec templates:** `plugins/nmg-sdlc/skills/writing-specs/templates/*.md`
+  - `requirements.md`, `design.md`, `tasks.md`
+- **Config template:** `openclaw/scripts/sdlc-config.example.json`
+
+Use `Glob` to find the skill's own `SKILL.md` path, then resolve `../../..` to get the plugin root. From the plugin root, resolve `../..` to get the marketplace root (which contains `openclaw/`).
+
+Read all template files. If a template file cannot be found, skip that category and note it in the summary.
+
+### Step 2: Scan Project Files
+
+Glob for existing project files:
+
+```
+.claude/steering/*.md
+.claude/specs/*/requirements.md
+.claude/specs/*/design.md
+.claude/specs/*/tasks.md
+sdlc-config.json
+```
+
+**Only analyze files that already exist.** Do not create missing files — suggest `/setting-up-steering` or `/writing-specs` for that.
+
+### Step 3: Analyze Steering Docs
+
+For each existing steering doc (e.g., `.claude/steering/product.md`):
+
+1. **Read the template file** (e.g., `setting-up-steering/templates/product.md`)
+2. **Extract template content** from inside the ` ```markdown ... ``` ` code block — the template files wrap their content in a fenced code block. Parse only the content between the opening ` ```markdown ` and the closing ` ``` `.
+3. **Parse headings** — Extract all `## ` headings from both the template content and the existing project file.
+4. **Diff headings** — Identify headings present in the template but absent from the project file.
+5. **Extract missing sections** — For each missing heading, extract the full section content from the template (from the `## ` heading to the next `## ` heading or end of content).
+6. **Determine insertion point** — Insert after the predecessor heading in template order. For example, if the template order is `## A`, `## B`, `## C` and `## B` is missing, insert it after the `## A` section's content.
+
+**Example:**
+
+```
+Template headings:    ## Mission, ## Target Users, ## Core Value Proposition, ## Product Principles, ## Success Metrics
+Existing headings:    ## Mission, ## Target Users, ## Core Value Proposition, ## Success Metrics
+Missing:              ## Product Principles
+Insert after:         ## Core Value Proposition (its predecessor in template order)
+```
+
+### Step 4: Analyze Spec Files
+
+For each spec file (`requirements.md`, `design.md`, `tasks.md`) in each spec directory:
+
+1. **Detect the variant** — Read the first `# ` heading in the existing file:
+   - **Feature variant:** `# Requirements:`, `# Design:`, `# Tasks:`
+   - **Defect variant:** `# Defect Report:`, `# Root Cause Analysis:`, `# Tasks:` with a flat summary table (Task/Description/Status columns)
+
+2. **Extract the correct template variant** — Each spec template file contains two code blocks:
+   - **First ` ```markdown ``` ` block** = feature variant
+   - **Second ` ```markdown ``` ` block** (after `# Defect` heading) = defect variant
+
+   Select the block matching the detected variant.
+
+3. **Same heading-diff logic as Step 3** — Parse `## ` headings, identify missing, extract section content, determine insertion point.
+
+**Variant detection rules for `tasks.md`** (both variants start with `# Tasks:`):
+- If the Summary table has columns `Phase | Tasks | Status` → feature variant
+- If the Summary table has columns `Task | Description | Status` → defect variant
+
+**Skip `feature.gherkin` files entirely** — these are generated from acceptance criteria, not templated.
+
+### Step 5: Analyze OpenClaw Config
+
+If `sdlc-config.json` exists in the project root:
+
+1. **Read both files** — the project's `sdlc-config.json` and the template `sdlc-config.example.json`
+2. **Compare root-level keys** — Identify keys present in the template but absent from the project config
+3. **Compare `steps.*` keys** — Identify missing step entries (e.g., a new step added to the template)
+4. **Compare step sub-keys** — For each step that exists in both, identify missing sub-keys (e.g., `skill`, `timeoutMin`)
+5. **Record missing keys at all levels** with their template default values
+
+**Important:** Never overwrite existing values. Only add keys that are entirely absent.
+
+### Step 6: Check OpenClaw Skill Version
+
+Compare the installed OpenClaw skill with the source in the marketplace clone:
+
+- **Installed:** `~/.openclaw/skills/running-sdlc/`
+- **Source:** `openclaw/skills/running-sdlc/` (relative to marketplace root)
+
+For each file in the source directory, read both the installed and source versions. If any file differs (or is missing from the installation), record a warning.
+
+If the installed skill is outdated or missing, suggest running `/installing-openclaw-skill` to update.
+
+If `~/.openclaw/skills/running-sdlc/` does not exist, note that OpenClaw is not installed and skip this check.
+
+### Step 7: Present Findings
+
+Display a per-file summary of all proposed changes. Group by category:
+
+```
+## Migration Summary
+
+### Steering Docs
+- **product.md** — Add 2 missing sections: "Product Principles", "Brand Voice"
+- **tech.md** — Up to date
+- **structure.md** — Not found (run /setting-up-steering to create)
+
+### Spec Files
+- **42-add-auth/requirements.md** — Add 1 missing section: "UI/UX Requirements"
+- **42-add-auth/design.md** — Up to date
+- **15-fix-login/requirements.md** (defect) — Up to date
+
+### OpenClaw Config
+- **sdlc-config.json** — Add 2 missing keys: "cleanup", "steps.merge"
+
+### OpenClaw Skill
+- ⚠ Installed skill is outdated — run /installing-openclaw-skill to update
+```
+
+If everything is up to date, report:
+
+```
+Everything is up to date — no migration needed.
+```
+
+And stop here.
+
+Otherwise, use `AskUserQuestion` to ask the user whether to proceed with the migration:
+
+```
+question: "Apply the migration changes listed above?"
+options:
+  - "Yes, apply all changes"
+  - "No, cancel migration"
+```
+
+**This skill does not support auto-mode.** Always present findings and wait for user approval.
+
+### Step 8: Apply Changes
+
+If the user approves:
+
+#### Markdown files (steering docs and specs)
+
+For each file with missing sections:
+
+1. Read the file
+2. For each missing section (in template order):
+   - Find the predecessor section's heading in the file
+   - Locate the end of the predecessor section (the line before the next `## ` heading, or end of file)
+   - Use `Edit` to insert the missing section content (including `---` separator and `## ` heading) after the predecessor section
+3. After all insertions, re-read the file to verify the new headings are present
+
+**Insertion format:** Insert a blank line, then `---`, then a blank line, then the full section content from the template (heading + body). Match the separator style used in the rest of the file.
+
+#### JSON config
+
+For the `sdlc-config.json`:
+
+1. Read the current file
+2. For each missing root-level key, add it with the template default value
+3. For each missing step entry, add it with the template default values
+4. For each existing step with missing sub-keys, add the missing sub-keys
+5. Write the updated JSON (preserve existing values, only add missing keys)
+6. Use `Edit` to add the missing keys — do not overwrite the entire file
+
+#### Output summary
+
+After applying changes, output a summary:
+
+```
+## Migration Complete
+
+### Changes Applied
+- **product.md** — Added sections: "Product Principles", "Brand Voice"
+- **sdlc-config.json** — Added keys: "cleanup", "steps.merge"
+
+### Skipped (already up to date)
+- tech.md, structure.md, 42-add-auth/design.md
+
+### Recommendations
+- Review added sections and customize placeholder content
+- Run /installing-openclaw-skill to update the OpenClaw skill
+```
+
+---
+
+## Key Rules
+
+1. **Never modify existing content** — Only insert new sections or add new keys
+2. **Never create files** — Only update files that already exist
+3. **Never overwrite values** — For JSON, only add keys that are absent
+4. **Skip `feature.gherkin`** — These are generated, not templated
+5. **Always interactive** — Present findings and wait for approval before applying
+6. **Self-updating** — Read templates at runtime; never hardcode template content
+
+---
+
+## Integration with SDLC Workflow
+
+Run this skill periodically after plugin updates to keep project files current:
+
+```
+/setting-up-steering (one-time)
+         ↓
+/migrating-projects (after plugin updates)
+         ↓
+/creating-issues  →  /writing-specs  →  /implementing-specs  →  /verifying-specs  →  /creating-prs
+```


### PR DESCRIPTION
## Summary

- **New `/migrating-projects` skill** that compares project files (steering docs, specs, OpenClaw config) against current plugin templates and merges in missing sections while preserving all user-written content
- Self-updating by design — reads templates at runtime, so new template sections are automatically detected without skill code changes
- Always interactive: presents proposed changes for user review before applying any modifications

## Acceptance Criteria

From `.claude/specs/25-add-migration-skill/requirements.md`:

- [ ] AC1: Steering doc migration — missing sections identified and merged while preserving user content
- [ ] AC2: Spec migration — missing sections identified and merged for both feature and defect variants
- [ ] AC3: User content preservation — existing content remains unchanged, new sections inserted with placeholders
- [ ] AC4: Interactive review before apply — all proposed changes presented for user approval
- [ ] AC5: Self-updating via runtime template reading — detects new template sections automatically
- [ ] AC6: OpenClaw config migration — missing JSON keys merged while preserving user-set values
- [ ] AC7: OpenClaw skill version check — warns if installed skill differs from source
- [ ] AC8: Already up-to-date — reports no changes needed when files match templates
- [ ] AC9: Missing files skipped — only existing files are migrated, missing files not created

## Test Plan

- [ ] BDD feature file with 9 scenarios covering all acceptance criteria (`.claude/specs/25-add-migration-skill/feature.gherkin`)

## Specs

- Requirements: `.claude/specs/25-add-migration-skill/requirements.md`
- Design: `.claude/specs/25-add-migration-skill/design.md`
- Tasks: `.claude/specs/25-add-migration-skill/tasks.md`

Closes Nunley-Media-Group/nmg-sdlc#21