### PR TITLE
fix: read steering docs during /creating-issues investigation (#27)

### DIFF
--- a/.claude/specs/27-fix-creating-issues-steering-docs/design.md
+++ b/.claude/specs/27-fix-creating-issues-steering-docs/design.md
@@ -1,0 +1,73 @@
+# Root Cause Analysis: Creating-issues skill does not read tech.md and structure.md during investigation
+
+**Issue**: #27
+**Date**: 2026-02-16
+**Status**: Draft
+**Author**: Claude Code
+
+---
+
+## Root Cause
+
+The `/creating-issues` skill's Step 3 (Investigate Codebase) defines two investigation sub-flows — one for Enhancement/Feature and one for Bug — but neither reads `.claude/steering/tech.md` or `.claude/steering/structure.md`.
+
+Step 1 reads only `product.md` for product context (vision, users, priorities), which is correct for its purpose. The assumption was that Step 3's codebase exploration (specs + source code) would surface all relevant constraints. However, technical constraints (e.g., "review Claude Code docs before modifying CC resources" in `tech.md`) and architectural patterns (e.g., layer responsibilities in `structure.md`) are only captured in steering documents, not in specs or source code. Without reading these documents, the investigation summary is incomplete and the resulting issue misses constraint-derived acceptance criteria.
+
+### Affected Code
+
+| File | Lines | Role |
+|------|-------|------|
+| `plugins/nmg-sdlc/skills/creating-issues/SKILL.md` | 46–59 | Step 3, Enhancement flow — explores specs and source code but not steering docs |
+| `plugins/nmg-sdlc/skills/creating-issues/SKILL.md` | 61–75 | Step 3, Bug flow — searches and traces code but not steering docs |
+
+### Triggering Conditions
+
+- `.claude/steering/tech.md` and/or `.claude/steering/structure.md` exist in the project
+- The enhancement or bug area is subject to constraints defined in those documents
+- These constraints are not duplicated in existing specs or source code comments
+
+---
+
+## Fix Strategy
+
+### Approach
+
+Add a new sub-step to both Enhancement and Bug flows within Step 3 that reads `tech.md` and `structure.md` (if they exist) and incorporates relevant constraints into the investigation summary. This is a minimal change — it adds one numbered item to each flow and augments the summary output to include a constraints section.
+
+The new sub-step should be inserted early in each flow (after initial exploration, before summarization) so that constraints inform the summary. For the Enhancement flow, it becomes a new item 3 (before "Summarize findings", which shifts to item 4). For the Bug flow, it becomes a new item 3 (before "Form hypothesis", which shifts to item 4, and "Confirm with user" shifts to item 5).
+
+### Changes
+
+| File | Change | Rationale |
+|------|--------|-----------|
+| `plugins/nmg-sdlc/skills/creating-issues/SKILL.md` | Add steering doc read step to Enhancement flow (after source exploration, before summarize) | Surfaces technical and architectural constraints for enhancements |
+| `plugins/nmg-sdlc/skills/creating-issues/SKILL.md` | Add steering doc read step to Bug flow (after code tracing, before hypothesis) | Surfaces constraints relevant to the bug's domain |
+| `plugins/nmg-sdlc/skills/creating-issues/SKILL.md` | Update summarize/hypothesis steps to include relevant constraints | Ensures constraints flow through to issue output |
+
+### Blast Radius
+
+- **Direct impact**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md` — only file modified
+- **Indirect impact**: None. Skills are prompt-based Markdown files; there are no callers or imports. The change affects Claude's behavior when executing `/creating-issues`, but does not touch any other skill, hook, or agent.
+- **Risk level**: Low — adding more information to the investigation step cannot break existing behavior; Step 1's `product.md` reading is untouched.
+
+---
+
+## Regression Risk
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Step 1 product.md reading is accidentally altered | Low | The fix only modifies Step 3; Step 1 is not touched |
+| Investigation takes noticeably longer due to extra reads | Low | Reading two small Markdown files adds negligible latency |
+| Constraints overwhelm the investigation summary | Low | The instructions specify surfacing only constraints *relevant to the enhancement/bug area*, not all constraints |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Root cause is identified with specific code references
+- [x] Fix is minimal — no unrelated refactoring
+- [x] Blast radius is assessed
+- [x] Regression risks are documented with mitigations
+- [x] Fix follows existing project patterns (per `structure.md`)

--- a/.claude/specs/27-fix-creating-issues-steering-docs/feature.gherkin
+++ b/.claude/specs/27-fix-creating-issues-steering-docs/feature.gherkin
@@ -1,0 +1,45 @@
+# File: .claude/specs/27-fix-creating-issues-steering-docs/feature.gherkin
+#
+# Generated from: .claude/specs/27-fix-creating-issues-steering-docs/requirements.md
+# Issue: #27
+# Type: Defect regression
+
+@regression
+Feature: Creating-issues investigation reads steering docs
+  The creating-issues skill's Step 3 (Investigate Codebase) previously did not read
+  tech.md or structure.md, causing technical and architectural constraints to be
+  invisible during issue creation. This was fixed by adding steering doc reads to
+  both the Enhancement and Bug investigation flows.
+
+  # --- Bug Is Fixed ---
+
+  @regression
+  Scenario: Steering docs are read during enhancement investigation
+    Given ".claude/steering/tech.md" and ".claude/steering/structure.md" exist in the project
+    When the creating-issues skill reaches Step 3 for an enhancement
+    Then it reads "tech.md" and "structure.md" alongside existing spec and source exploration
+    And surfaces any constraints relevant to the enhancement area in the investigation summary
+
+  @regression
+  Scenario: Steering docs are read during bug investigation
+    Given ".claude/steering/tech.md" and ".claude/steering/structure.md" exist in the project
+    When the creating-issues skill reaches Step 3 for a bug
+    Then it reads "tech.md" and "structure.md" alongside existing code search and tracing
+    And incorporates relevant constraints into the root cause hypothesis
+
+  # --- Related Behavior Still Works ---
+
+  @regression
+  Scenario: Product steering is still read in Step 1
+    Given ".claude/steering/product.md" exists in the project
+    When the creating-issues skill executes Step 1 (Gather Context)
+    Then "product.md" is read for product vision, users, and priorities
+    And the Step 1 behavior is unchanged from before the fix
+
+  # --- Constraints Flow to Output ---
+
+  @regression
+  Scenario: Relevant constraints surface in issue output
+    Given "tech.md" contains a constraint relevant to the enhancement area
+    When the issue is synthesized in Step 5
+    Then the relevant constraint is reflected in the issue's acceptance criteria or notes section

--- a/.claude/specs/27-fix-creating-issues-steering-docs/requirements.md
+++ b/.claude/specs/27-fix-creating-issues-steering-docs/requirements.md
@@ -1,0 +1,99 @@
+# Defect Report: Creating-issues skill does not read tech.md and structure.md during investigation
+
+**Issue**: #27
+**Date**: 2026-02-16
+**Status**: Draft
+**Author**: Claude Code
+**Severity**: Medium
+**Related Spec**: `.claude/specs/4-creating-issues-skill/`
+
+---
+
+## Reproduction
+
+### Steps to Reproduce
+
+1. Ensure `.claude/steering/tech.md` exists with constraints relevant to an enhancement area (e.g., the "Claude Code Resource Development" directive on line 85)
+2. Ensure `.claude/steering/structure.md` exists with architectural patterns
+3. Run `/creating-issues` and describe an enhancement to a Claude Code resource (e.g., modifying a SKILL.md)
+4. Observe Step 3 (Investigate Codebase) — it explores existing specs and source code but never reads `tech.md` or `structure.md`
+5. The resulting issue is missing acceptance criteria derived from steering document constraints
+
+### Environment
+
+| Factor | Value |
+|--------|-------|
+| **OS / Platform** | macOS (Darwin 25.3.0) |
+| **Version / Commit** | nmg-sdlc 2.6.0 |
+| **Browser / Runtime** | Claude Code CLI (latest) |
+| **Configuration** | Standard plugin installation with all three steering docs present |
+
+### Frequency
+
+Always — the skill never reads `tech.md` or `structure.md` in any code path during Step 3.
+
+---
+
+## Expected vs Actual
+
+| | Description |
+|---|-------------|
+| **Expected** | Step 3 reads `tech.md` and `structure.md` during investigation, surfacing any constraints relevant to the enhancement area — which are then incorporated into the issue's acceptance criteria or notes |
+| **Actual** | Step 3 only explores existing specs and source code. `tech.md` and `structure.md` are never consulted, so constraints like "review Claude Code docs before modifying CC resources" are invisible and absent from the created issue |
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Bug Is Fixed — Steering Docs Are Read During Investigation
+
+**Given** `.claude/steering/tech.md` and `.claude/steering/structure.md` exist in the project
+**When** the creating-issues skill reaches Step 3 (Investigate Codebase)
+**Then** it reads `tech.md` and `structure.md` alongside the existing spec/source exploration and surfaces any constraints relevant to the enhancement area
+
+### AC2: No Regression — Product Steering Still Read in Step 1
+
+**Given** `.claude/steering/product.md` exists in the project
+**When** the creating-issues skill executes Step 1 (Gather Context)
+**Then** `product.md` is still read for product vision, users, and priorities as it is today
+
+### AC3: Constraints Surface in Issue Output
+
+**Given** `tech.md` contains a constraint relevant to the enhancement area (e.g., "review Claude Code docs before modifying CC resources")
+**When** the issue is synthesized in Step 5
+**Then** the relevant constraint is reflected in the issue's acceptance criteria or notes section
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR1 | Step 3 reads `tech.md` and `structure.md` during investigation for both enhancement and bug flows | Must |
+| FR2 | Relevant constraints from steering docs are surfaced in the investigation summary | Must |
+| FR3 | Existing Step 1 `product.md` reading is unchanged | Must |
+
+---
+
+## Out of Scope
+
+- Changing which steering docs Step 1 reads (product context gathering is separate from technical investigation)
+- Adding new steering document types beyond the existing three
+- Changes to the writing-specs or other skills (even if they have similar gaps)
+- Auto-mode flow changes (auto-mode skips Step 3 entirely)
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] Reproduction steps are repeatable and specific
+- [x] Expected vs actual behavior is clearly stated
+- [x] Severity is assessed
+- [x] Acceptance criteria use Given/When/Then format
+- [x] At least one regression scenario is included
+- [x] Fix scope is minimal — no feature work mixed in
+- [x] Out of scope is defined

--- a/.claude/specs/27-fix-creating-issues-steering-docs/tasks.md
+++ b/.claude/specs/27-fix-creating-issues-steering-docs/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Creating-issues skill does not read tech.md and structure.md during investigation
+
+**Issue**: #27
+**Date**: 2026-02-16
+**Status**: Planning
+**Author**: Claude Code
+
+---
+
+## Summary
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T001 | Fix the defect — add steering doc reads to Step 3 | [ ] |
+| T002 | Add regression test (Gherkin feature file) | [ ] |
+| T003 | Verify no regressions | [ ] |
+
+---
+
+### T001: Fix the Defect
+
+**File(s)**: `plugins/nmg-sdlc/skills/creating-issues/SKILL.md`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] Enhancement flow in Step 3 includes a new sub-step (item 3) that reads `.claude/steering/tech.md` and `.claude/steering/structure.md` if they exist
+- [ ] Bug flow in Step 3 includes a new sub-step (item 3) that reads `.claude/steering/tech.md` and `.claude/steering/structure.md` if they exist
+- [ ] Enhancement flow's "Summarize findings" step (now item 4) includes a bullet for relevant technical/architectural constraints from steering docs
+- [ ] Bug flow's "Form hypothesis" step (now item 4) accounts for constraints from steering docs when formulating the root cause hypothesis
+- [ ] Step 1 (`product.md` reading) is unchanged
+- [ ] Auto-mode note ("This step is skipped") remains unchanged
+- [ ] No unrelated changes included in the diff
+
+**Notes**: Follow the fix strategy from design.md. The new sub-step should instruct Claude to read both documents (if they exist) and note any constraints relevant to the enhancement/bug area. Use conditional language ("if it exists") since not all projects will have all three steering docs.
+
+### T002: Add Regression Test
+
+**File(s)**: `.claude/specs/27-fix-creating-issues-steering-docs/feature.gherkin`
+**Type**: Create
+**Depends**: T001
+**Acceptance**:
+- [ ] Gherkin scenario reproduces the original bug condition (Step 3 without steering doc reads)
+- [ ] Scenario tagged `@regression`
+- [ ] Scenario for AC1 (steering docs read during investigation)
+- [ ] Scenario for AC2 (product.md still read in Step 1)
+- [ ] Scenario for AC3 (constraints surface in issue output)
+
+### T003: Verify No Regressions
+
+**File(s)**: Existing skill file and specs
+**Type**: Verify (no file changes)
+**Depends**: T001, T002
+**Acceptance**:
+- [ ] Step 1 still instructs reading `product.md` for product context
+- [ ] Step 3 Enhancement flow still explores specs and source code (items 1 and 2 unchanged)
+- [ ] Step 3 Bug flow still searches code and traces paths (items 1 and 2 unchanged)
+- [ ] Auto-mode note is preserved
+- [ ] No side effects in related code paths (per blast radius from design.md)
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Tasks are focused on the fix — no feature work
+- [x] Regression test is included (T002)
+- [x] Each task has verifiable acceptance criteria
+- [x] No scope creep beyond the defect
+- [x] File paths reference actual project structure (per `structure.md`)

--- a/plugins/nmg-sdlc/skills/creating-issues/SKILL.md
+++ b/plugins/nmg-sdlc/skills/creating-issues/SKILL.md
@@ -51,10 +51,12 @@ Based on the classification from Step 2, perform a targeted codebase investigati
 
 1. **Explore existing specs**: Use `Glob` for `.claude/specs/*/requirements.md` and read any that relate to the area described by the user
 2. **Explore source code**: Use `Glob` and `Grep` to find files related to the enhancement area (e.g., the relevant SKILL.md, templates, hooks, or application code)
-3. **Summarize findings**: Produce a "Current State" summary capturing:
+3. **Read steering docs**: Read `.claude/steering/tech.md` and `.claude/steering/structure.md` (if they exist) and note any technical or architectural constraints relevant to the enhancement area
+4. **Summarize findings**: Produce a "Current State" summary capturing:
    - What exists today (relevant code, patterns, specs)
    - How the current implementation works
    - What patterns should be preserved or built upon
+   - Relevant constraints from steering docs (e.g., required review steps, technology restrictions, structural rules)
 
 If no relevant code or specs are found, note that this appears to be a greenfield addition and move on.
 
@@ -62,11 +64,13 @@ If no relevant code or specs are found, note that this appears to be a greenfiel
 
 1. **Search for related code**: Use `Grep` to find code related to the bug description (error messages, function names, file patterns the user mentioned)
 2. **Trace code paths**: `Read` the relevant files and follow the logic through the affected paths
-3. **Form hypothesis**: Formulate a root cause hypothesis describing:
+3. **Read steering docs**: Read `.claude/steering/tech.md` and `.claude/steering/structure.md` (if they exist) and note any constraints relevant to the bug's domain
+4. **Form hypothesis**: Formulate a root cause hypothesis describing:
    - What code is involved
    - What the incorrect behavior or assumption is
    - Why it manifests as the reported bug
-4. **Confirm with user**: Present the hypothesis via `AskUserQuestion`:
+   - Any steering doc constraints that inform the fix approach
+5. **Confirm with user**: Present the hypothesis via `AskUserQuestion`:
    - "Yes, that matches"
    - "Not quite — let me clarify"
 


### PR DESCRIPTION
## Summary

- **Bug fix**: The `/creating-issues` skill's Step 3 (Investigate Codebase) now reads `.claude/steering/tech.md` and `.claude/steering/structure.md` alongside existing spec/source exploration
- **Why**: Technical and architectural constraints in steering docs were invisible during issue creation, causing issues to be created without relevant acceptance criteria (e.g., the "review Claude Code docs before modifying CC resources" directive)
- **Scope**: Minimal — only Step 3 of `creating-issues/SKILL.md` was modified; Step 1 (`product.md` reading) is unchanged

## Acceptance Criteria

From `.claude/specs/27-fix-creating-issues-steering-docs/requirements.md`:

- [ ] AC1: Steering docs (`tech.md`, `structure.md`) are read during Step 3 investigation for both enhancement and bug flows
- [ ] AC2: No regression — `product.md` is still read in Step 1 for product context
- [ ] AC3: Relevant constraints from steering docs surface in the synthesized issue output

## Test Plan

From `.claude/specs/27-fix-creating-issues-steering-docs/tasks.md`:

- [ ] T001: Verified Step 3 enhancement and bug flows both include new steering doc read sub-step
- [ ] T002: Gherkin regression test added (`feature.gherkin`) covering AC1–AC3
- [ ] T003: Verified no regressions — Step 1, auto-mode note, and existing Step 3 sub-steps unchanged

## Specs

- Requirements: `.claude/specs/27-fix-creating-issues-steering-docs/requirements.md`
- Design: `.claude/specs/27-fix-creating-issues-steering-docs/design.md`
- Tasks: `.claude/specs/27-fix-creating-issues-steering-docs/tasks.md`

Closes Nunley-Media-Group/nmg-sdlc#23