### PR TITLE
docs: add specs for refactor SKILL.md progressive disclosure (#138)

### DIFF
--- a/specs/feature-refactor-skill-md-progressive-disclosure/design.md
+++ b/specs/feature-refactor-skill-md-progressive-disclosure/design.md
@@ -1,0 +1,414 @@
+# Design: Refactor SKILL.md via Progressive Disclosure
+
+**Issues**: #138
+**Date**: 2026-04-19
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## Overview
+
+This refactor splits every nmg-sdlc SKILL.md into a lean body (trigger + workflow skeleton) and on-demand reference material loaded from two new layers: a **plugin-shared `references/`** for content that today appears verbatim in multiple skills, and a **per-skill `references/`** for variant-specific or rarely-executed branches. The pattern is already proven in-repo by `verify-code`, which has `checklists/` + `references/`; this work generalizes that layout plugin-wide and adds a deterministic content-inventory audit script so AI-authored rewrites cannot silently drop directives.
+
+The scope is mechanical: move content, leave behavior alone. Every observable property of every skill — the frontmatter, the slash command surface, the generated artifacts under exercise — must be byte- or spec-equivalent to the pre-refactor baseline. The audit script, an exercise-testing rubric, and a staged 4-PR rollout form the safety net.
+
+A permanent audit script at `scripts/skill-inventory-audit.mjs` plus a baseline inventory JSON committed with the refactor guards every future SKILL.md edit against silent content loss, turning AC6 into a CI-enforced invariant rather than a one-shot check.
+
+---
+
+## Architecture
+
+### New Directory Layout
+
+```
+plugins/nmg-sdlc/
+├── references/                          ← NEW: plugin-shared references
+│   ├── legacy-layout-gate.md
+│   ├── unattended-mode.md
+│   ├── feature-naming.md
+│   ├── versioning.md
+│   ├── steering-schema.md
+│   └── spec-frontmatter.md
+└── skills/
+    ├── draft-issue/
+    │   ├── SKILL.md                     ← ≤ 300 lines (was 1087)
+    │   └── references/                  ← NEW: per-skill references
+    │       ├── multi-issue.md
+    │       ├── design-url.md
+    │       ├── interview-depth.md
+    │       ├── feature-template.md
+    │       └── bug-template.md
+    ├── write-spec/
+    │   ├── SKILL.md                     ← ≤ 250 lines (was 516)
+    │   ├── templates/                   ← unchanged
+    │   └── references/
+    │       ├── discovery.md
+    │       ├── amendment-mode.md
+    │       ├── defect-variant.md
+    │       └── review-gates.md
+    ├── verify-code/
+    │   ├── SKILL.md                     ← ≤ 220 lines (was 437)
+    │   ├── checklists/                  ← unchanged (existing split)
+    │   └── references/                  ← expanded
+    ...
+scripts/
+├── skill-inventory-audit.mjs            ← NEW: deterministic content-inventory check
+├── skill-inventory.baseline.json        ← NEW: committed pre-refactor inventory
+└── __tests__/
+    └── skill-inventory-audit.test.js    ← NEW: unit tests for the audit script
+```
+
+### Content-Flow Diagram
+
+```
+┌───────────────────────────────┐
+│  Claude Code loads SKILL.md   │
+│  (trigger + workflow skeleton)│
+└──────────┬────────────────────┘
+           │
+           │  workflow reaches a branch that needs detail
+           ▼
+┌───────────────────────────────────────────┐
+│  Pointer: Read `references/{name}.md`     │
+│  when {explicit triggering condition}     │
+└──────────┬────────────────────────────────┘
+           │
+           ├─► plugins/nmg-sdlc/references/{name}.md    (shared across skills)
+           └─► plugins/nmg-sdlc/skills/{skill}/references/{name}.md  (this skill only)
+```
+
+A skill always loads its own body. Reference files are loaded only when a pointer fires, which is what earns the "progressive disclosure" context savings.
+
+### Layer Responsibilities
+
+| Layer | Holds | Does Not Hold |
+|-------|-------|---------------|
+| SKILL.md body | Trigger, workflow skeleton, gate structure, pointer lines | Full variant branches, exhaustive examples, duplicated cross-skill rules |
+| Plugin-shared `references/` | Rules repeated ≥ 3 skills verbatim or near-verbatim | Skill-specific workflow steps |
+| Per-skill `references/` | Variant branches, extended examples, long-form walkthroughs | Content other skills consume |
+| `templates/` (existing) | Declarative output structures | Conditional logic |
+| `checklists/` (existing, verify-code only) | Scoring rubrics | Workflow steps |
+
+---
+
+## Pointer Grammar (satisfies AC7)
+
+Every pointer from a SKILL.md to a reference file follows one of two shapes:
+
+**Shared reference:**
+```
+Read `../../references/{name}.md` when {triggering-condition}.
+```
+
+**Per-skill reference:**
+```
+Read `references/{name}.md` when {triggering-condition}.
+```
+
+Rules:
+1. The reference path is in single backticks.
+2. The triggering condition is stated in the same sentence, never delegated to surrounding prose.
+3. `when` is the only conjunction used (not "if", "on", "where"), so pointers are greppable.
+4. Relative paths are always relative to the SKILL.md that contains the pointer — plugin-shared references resolve via `../../references/`.
+5. A pointer may optionally append a brief purpose fragment: `Read `references/defect-variant.md` when the issue has the `bug` label — it replaces the full feature template.`
+
+Rule #3 means `grep -rE '^Read \`(\.\./\.\./)?references/[^`]+\.md\` when ' plugins/nmg-sdlc/skills/*/SKILL.md` enumerates every pointer plugin-wide. The audit script depends on this.
+
+---
+
+## Shared-Reference Contents
+
+Each of the six plugin-shared references consolidates content currently duplicated across skills. The design below names what each file must contain — line counts are soft targets, not contracts.
+
+| File | Consolidated from | Sketch of contents |
+|------|--------------------|---------------------|
+| `legacy-layout-gate.md` | draft-issue, start-issue, write-spec, write-code, verify-code, open-pr, onboard-project, upgrade-project | Glob check for `.claude/steering/*.md` + `.claude/specs/*/requirements.md`; abort message (reworded per FR5 — no `ERROR:` prefix required since no downstream parser depends on it); action: instruct user to run `/upgrade-project`. |
+| `unattended-mode.md` | every pipeline skill | Check for `.claude/unattended-mode` file; semantics: skip every `AskUserQuestion` gate; the invariant "interactive mode is default, unattended is opt-in"; how each gate references this file in its own flow. |
+| `feature-naming.md` | draft-issue, start-issue, write-spec, verify-code, open-pr | Slug derivation rules; `feature-` vs `bug-` prefix rules; fallback discovery by issue number in `**Issues**` frontmatter; legacy `{issue#}-{slug}/` support. |
+| `versioning.md` | open-pr, draft-issue | Plugin version bump matrix (label → bump type); major-bump opt-in (`--major`); dual-file update (plugin.json + marketplace.json); CHANGELOG conventions including `### Changed (BREAKING)` + `### Migration Notes`. |
+| `steering-schema.md` | onboard-project, write-spec, verify-code, open-pr | Roster of steering docs (product.md, tech.md, structure.md, retrospective.md); the purpose and read-timing of each; how skills discover and read them. |
+| `spec-frontmatter.md` | write-spec, verify-code, run-retro | Frontmatter fields (`**Issues**`, `**Date**`, `**Status**`, `**Author**`, `**Related Spec**`); plural `**Issues**` vs legacy singular `**Issue**`; amendment rules; `Change History` table format. |
+
+---
+
+## Per-Skill Reference Extractions
+
+For each skill, the following content moves out of SKILL.md into per-skill `references/`. The SKILL.md retains a trigger + pointer for each. Exact extraction is refined during implementation, but these are the anchors the design commits to.
+
+| Skill | Extractions → `references/` | Ceiling |
+|-------|------------------------------|---------|
+| draft-issue | `multi-issue.md`, `design-url.md`, `interview-depth.md`, `feature-template.md`, `bug-template.md` | ≤ 300 |
+| upgrade-project | `detection.md`, `migration-steps.md`, `verification.md` | ≤ 250 |
+| write-spec | `discovery.md`, `amendment-mode.md`, `defect-variant.md`, `review-gates.md` | ≤ 250 |
+| onboard-project | `greenfield.md`, `brownfield.md`, `interview.md` | ≤ 280 |
+| start-issue | `dirty-tree.md`, `milestone-selection.md` | ≤ 220 |
+| verify-code | `exercise-testing.md` (exists), `autofix-loop.md`, `defect-path.md` | ≤ 220 |
+| run-retro | `learning-extraction.md`, `transferability.md` | ≤ 180 |
+| open-pr | `version-bump.md`, `ci-monitoring.md` | ≤ 180 |
+| write-code | `plan-mode.md`, `resumption.md` | ≤ 180 |
+
+Each per-skill `references/` directory stays under 5 files (AC8). Any reference exceeding 300 lines prepends a TOC in its first 30 lines.
+
+### Selection Criteria for Extraction
+
+A section moves to `references/` when **any** of these are true:
+- It fires only on a specific variant (e.g., `bug` label, amendment mode, `--major`).
+- It fires only rarely — not on the typical happy path.
+- It duplicates content appearing in ≥ 2 other SKILL.md files (→ plugin-shared).
+- It is an extended example or walkthrough the skill can cite rather than inline.
+
+A section **stays inline** when:
+- It fires on every invocation.
+- Removing it would break the workflow skeleton's readability end-to-end.
+- Its removal would require the pointer's trigger clause to carry more than a short phrase's worth of context.
+
+---
+
+## Content-Inventory Audit Script (satisfies AC6 + FR11)
+
+### Purpose
+
+Catch silent content loss when AI agents rewrite SKILL.md bodies. The script is permanent: it runs in CI on every PR that touches any SKILL.md or `references/` file and fails the build when the inventory diverges from the committed baseline without a justification comment in the PR body.
+
+### Location and Shape
+
+- `scripts/skill-inventory-audit.mjs` — Node.js ESM, zero-dependency, follows tech.md conventions.
+- `scripts/skill-inventory.baseline.json` — committed inventory file, regenerated only on intentional removals.
+- `scripts/__tests__/skill-inventory-audit.test.js` — Jest tests covering the extraction rules.
+
+### Inventory Extraction Rules
+
+An inventory item is a normalized clause from a SKILL.md body. The script walks every `plugins/nmg-sdlc/skills/*/SKILL.md` and every `plugins/nmg-sdlc/**/references/*.md`, extracting items under these headings:
+
+- `## Input` clauses
+- `## Process` / `### Step N` clauses
+- `## Output` clauses
+- `## Human Review Gate` / `### Human Review Gate` clauses
+- Any line containing the substring `unattended-mode`
+
+Each extracted item is normalized: trim whitespace, collapse consecutive spaces, strip markdown emphasis (`**`, `_`), lowercase the first 80 characters, and hash (SHA-1) the normalized form. The item ID is the 12-char prefix of the hash.
+
+### Data Shape
+
+```json
+{
+  "generated_at": "2026-04-19T12:00:00Z",
+  "items": [
+    {
+      "id": "a1b2c3d4e5f6",
+      "source_before": "plugins/nmg-sdlc/skills/draft-issue/SKILL.md:142",
+      "normalized": "step 3: read steering/product.md for user context",
+      "destination": "plugins/nmg-sdlc/skills/draft-issue/SKILL.md:74"
+    },
+    {
+      "id": "f6e5d4c3b2a1",
+      "source_before": "plugins/nmg-sdlc/skills/draft-issue/SKILL.md:240",
+      "normalized": "defect requirements variant uses reproduction steps...",
+      "destination": "plugins/nmg-sdlc/skills/draft-issue/references/bug-template.md:8"
+    }
+  ]
+}
+```
+
+### Audit Modes
+
+| Mode | Invocation | Behavior |
+|------|-----------|----------|
+| `--baseline` | `node scripts/skill-inventory-audit.mjs --baseline` | Scans current checkout and writes `skill-inventory.baseline.json`. Intended for the refactor PR and intentional-removal PRs only. |
+| `--check` (default) | `node scripts/skill-inventory-audit.mjs` | Scans current checkout, loads baseline, reports any items missing from the new layout. Exits 0 if clean, 1 if items are unmapped. |
+| `--diff` | `node scripts/skill-inventory-audit.mjs --diff` | Prints a human-readable diff of inventory items `source_before` → `destination` for PR review. |
+
+### CI Integration
+
+A GitHub Actions workflow at `.github/workflows/skill-inventory-audit.yml` runs `--check` on every PR that modifies any `SKILL.md` or any file under `plugins/nmg-sdlc/**/references/`. A failing audit blocks merge. To intentionally remove inventory items, the PR author regenerates the baseline with `--baseline`, commits the updated JSON, and documents the removal in the PR body under a `### Inventory Removals` heading.
+
+### Failure Modes and Recovery
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| Unmapped item in `--check` | Content silently dropped during a refactor | Restore the content or regenerate baseline with justification |
+| Baseline file missing | First run before baseline committed | Run `--baseline` once, commit the output |
+| Normalization collision | Two clauses normalize to identical hashes | Extend normalization (e.g., include parent heading); re-baseline |
+
+### Script Lifecycle & Self-Maintenance
+
+The script is only useful if it stays correct and is actually exercised on every SKILL.md edit. Five overlapping mechanisms guard both properties.
+
+#### 1. Canary Fixture (self-test)
+
+- `scripts/__fixtures__/audit-canary/good/` — a known-good SKILL.md + references/ pair that the audit must accept.
+- `scripts/__fixtures__/audit-canary/bad/` — a SKILL.md with a deliberately dropped inventory item that the audit must reject (exit 1).
+- A Jest test and a CI job run `--check` against both fixtures. If the script's extraction logic ever breaks so drift goes undetected, the `bad/` fixture case fails — loudly.
+
+#### 2. Baseline-Freshness Check
+
+On every PR, the audit workflow:
+1. Computes a fresh baseline to a temp file (`node scripts/skill-inventory-audit.mjs --baseline --output /tmp/baseline.json`).
+2. Diffs it against `scripts/skill-inventory.baseline.json`, ignoring files touched by the PR.
+3. Fails if unrelated items drifted — that means a previous merge rotted the baseline.
+
+This catches the case where a skill edit sneaks through without updating the baseline and subsequent PRs build on stale state.
+
+#### 3. CI Enforcement — Required Check
+
+- The GitHub Actions job at `.github/workflows/skill-inventory-audit.yml` is declared a **required status check** on the `main` branch-protection rules. No merge without green.
+- The job runs the canary fixture from #1 before the real audit, so a broken script is reported as "canary failed" rather than "audit passed trivially."
+
+#### 4. `/verify-code` Integration
+
+`/verify-code`'s skill-exercise path invokes the audit script whenever any `plugins/nmg-sdlc/skills/**/SKILL.md` or `plugins/nmg-sdlc/**/references/**` file is in the diff. Implementation: add a new verification gate in `steering/tech.md`'s Verification Gates table that maps the condition to `node scripts/skill-inventory-audit.mjs --check`. Local dev invocations of `/verify-code` exercise the audit automatically — dogfooding the tooling on top of the CI hard gate.
+
+#### 5. Baseline Regeneration Controls
+
+Updates to `scripts/skill-inventory.baseline.json` are special:
+
+- The audit workflow, when it detects a change to the baseline file, lints the PR body for a `### Inventory Removals` heading. Missing heading → fail with a message naming the missing heading. Removal entries under the heading require: the inventory-item ID, the reason for removal, and the author's explicit confirmation that the removal is intentional.
+- Commit convention: baseline-regeneration commits use the `chore(inventory):` scope so regens are grep-able in git history.
+- Local helper: `node scripts/skill-inventory-audit.mjs --diff` prints the before/after destination map that can be pasted into the PR body as a starting point.
+
+Together these mechanisms make silent content loss require active, deliberate subversion — not possible through normal AI agent-driven edits.
+
+---
+
+## Exercise Testing Approach (satisfies AC2)
+
+AC2 demands that each refactored skill produce the same artifacts as before when exercised against a fixture. Fixtures live at `scripts/__fixtures__/skill-exercise/` (new directory) and the runner at `scripts/skill-exercise-runner.mjs` (new, zero-dependency) spawns `claude -p --plugin-dir ./plugins/nmg-sdlc --project-dir <fixture>` via the Agent SDK pattern already documented in `steering/tech.md`.
+
+For each refactored skill:
+
+1. Record the pre-refactor output against the fixture on the main branch.
+2. Apply the refactor on the topic branch.
+3. Re-run the same invocation.
+4. Compare:
+   - **Deterministic artifacts** (file paths, structural fields, frontmatter, slash-command enumeration): byte-equivalent check.
+   - **Model-authored prose** (issue bodies, spec content): graded against a rubric stored at `scripts/__fixtures__/skill-exercise/rubrics/{skill}.md` — same rubric the `/verify-code` pipeline already uses for plugin-scoped skills.
+
+Skills using `AskUserQuestion` use the `canUseTool` callback to auto-select the first option (per `steering/tech.md` → "Automated Exercise Testing via Agent SDK"), keeping runs deterministic.
+
+---
+
+## Claude Code GitHub App Integration (satisfies AC10 + FR14)
+
+The Claude Code GitHub App is already installed org-wide on Nunley-Media-Group with access to this repo; the remaining work is a repo-level workflow that invokes the official action on every PR.
+
+### Workflow
+
+- File: `.github/workflows/claude-review.yml`
+- Action: `anthropics/claude-code-action@v1`
+- Triggers:
+  - `pull_request`: `opened`, `synchronize` — automatic review on every PR and on every push to an open PR.
+  - `issue_comment`: `created` — with a `contains(github.event.comment.body, '@claude')` condition so Claude responds to explicit mentions in PR/issue threads.
+- Permissions: `contents: read`, `pull-requests: write`, `issues: write`.
+- Secrets: `ANTHROPIC_API_KEY` at the org level (already provisioned alongside the app). No repo-level secret configuration required.
+- Concurrency: `group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}`, `cancel-in-progress: true` — coalesces rapid pushes into a single review run to contain cost.
+
+### Context Claude Reads
+
+The action picks up `CLAUDE.md` at the project root automatically. No additional configuration is needed to steer reviews toward the plugin's conventions — `CLAUDE.md` already documents the version-bump matrix, commit style, README-sync rule, and spec-commitment rule.
+
+### Scope Boundary
+
+The workflow runs independently of the skill-inventory audit. The audit is a hard gate (required check); the Claude review is advisory — it posts comments but does not block merge. Keeping the two decoupled means a broken review workflow doesn't stall the refactor PRs.
+
+---
+
+## Rollout Plan (satisfies FR10)
+
+Four PRs in strict order, each independently mergeable and reverting cleanly:
+
+| PR | Scope | Gates |
+|----|-------|-------|
+| **1** | Additive: create `plugins/nmg-sdlc/references/` with the 6 shared files. Add `scripts/skill-inventory-audit.mjs` + baseline + canary fixtures + CI workflow (required-check) + `/verify-code` integration + `.github/workflows/claude-review.yml` (AC10/FR14). **No SKILL.md edits yet** — audit baseline captures the pre-refactor state. | Runner tests pass; audit `--check` reports zero drift; canary fixture test passes; `/verify-code` invokes audit on a sample skill edit; Claude Code review posts on PR 1 itself (self-dogfood). |
+| **2** | `draft-issue` pilot — migrate the biggest skill first and validate the pattern before touching others. Adds per-skill `references/` and updates pointers. | AC1 met for draft-issue; exercise test against fixture; audit `--check` passes with updated baseline. |
+| **3** | `write-spec` + `onboard-project` + `upgrade-project`. Apply lessons from PR 2. | AC1 met for all three; exercise tests pass; audit clean. |
+| **4** | Remainder: `start-issue`, `verify-code`, `run-retro`, `open-pr`, `write-code`. | Every skill at target; full audit clean; `steering/structure.md` updated (FR12); version bump to 1.53.0 (FR9); CHANGELOG entry. |
+
+A 5th PR is not planned — FR9 rides on PR 4.
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: One big-bang PR** | Refactor every skill in a single PR. | Simpler review surface; no interim states. | Massive diff; high regression risk; hard to revert a single skill. | Rejected — blast radius is too large for AI-authored markdown edits. |
+| **B: Per-skill PRs (9 PRs)** | One PR per skill. | Smallest possible blast radius. | PR-review overhead; shared-references PR must land first; 9 separate reviews. | Rejected — overhead outweighs the marginal blast-radius reduction over 4 PRs. |
+| **C: Staged 4-PR rollout** | Additive references first, then pilot, then bulk, then remainder. | Catches pattern flaws in the pilot; each PR is independently revertible; audit script lands before refactor begins. | Requires discipline to not touch unrefactored skills in interim PRs. | **Selected**. |
+| **D: One-shot audit (no permanent script)** | Run inventory check once on refactor PRs, delete afterwards. | Less tooling to maintain. | AC6's guarantee evaporates after merge; future skill edits can silently drop content. | Rejected — contradicts FR11 (resolved open question) and the retrospective learning that AI agent compliance is probabilistic. |
+| **E: Markdown-link pointer grammar** (`[text](path)`) | Use `verify-code`'s existing markdown-link style. | Consistent with existing skill. | Loses the `when {trigger}` clause; harder to grep; weaker disclosure-intent signal. | Rejected — AC7 specifies the uniform `Read ... when ...` grammar. `verify-code` updates its pointers during PR 4. |
+
+---
+
+## Security Considerations
+
+- [x] **No secrets introduced**: the refactor moves prose between markdown files.
+- [x] **No new external services**: audit script is local-only Node.
+- [x] **Input validation**: audit script treats file paths from CLI args with `path.resolve` and constrains scans to `plugins/nmg-sdlc/` and its subtree.
+- [x] **No shell injection**: script uses `node:fs` for file reads; no `exec` of user-derived strings.
+
+## Performance Considerations
+
+- [x] **Skill triggering latency**: reducing SKILL.md body size should improve latency or leave it unchanged. NFR requires no regression vs baseline.
+- [x] **Audit script runtime**: scan of ~13 SKILL.md + ~30 reference files is sub-second; CI cost negligible.
+- [x] **On-demand loading**: reference files load only when their pointer fires, reducing context consumption on typical skill runs.
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Audit script | Unit (Jest) | Inventory extraction, normalization, hash stability, mode flags, exit codes |
+| Audit script | Integration | End-to-end scan of the actual plugin directory, baseline round-trip |
+| Audit script | Canary fixture | `good/` fixture passes, `bad/` fixture exits 1 — fails loudly if extraction logic breaks |
+| Audit script | Baseline freshness | Fresh-baseline vs committed-baseline diff, ignoring PR-touched files |
+| Refactored skills | Exercise (Agent SDK) | Each refactored skill exercised against its fixture; outputs graded per rubric |
+| Frontmatter invariant | Structural | Diff script comparing frontmatter pre/post per skill (AC5) |
+| Pointer grammar | Structural | Regex check every pointer matches the grammar from AC7 |
+| Reference-file budget | Structural | `ls plugins/nmg-sdlc/skills/*/references/ | wc -l` ≤ 5 per skill |
+| Line-count targets | Structural | `wc -l` against the AC1 table; CI gate |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| AI agent rewrites a skill and silently drops a gate or step | **High** | **High** | Permanent audit script (FR11) runs in CI on every SKILL.md edit; canary fixture catches broken extraction logic; baseline regeneration is an explicit PR-body-documented act guarded by the workflow's `### Inventory Removals` lint. |
+| Audit script itself rots or is silently bypassed | Medium | High | Canary fixture + required-check branch protection + baseline-freshness diff + `/verify-code` local invocation form overlapping guards — bypassing one still leaves three. |
+| Exercise fixtures go stale or become too coupled to current prose | Medium | Medium | Grade prose against a rubric (not exact match); deterministic-artifact check catches structural drift cheaply. |
+| Pointer grammar is inconsistent across the refactor | Medium | Low | Regex check in CI enforces grammar (AC7 structural test). |
+| Shared-reference wording change unintentionally alters one consumer's semantics | Medium | Medium | AC9 preserves normative intent; PR review diffs each shared reference against every consuming skill's pre-refactor passages. |
+| Reference-file sprawl — too many per-skill files | Low | Medium | AC8 budget of ≤ 5; enforced structurally. |
+| verify-code's existing `[text](path)` pointers conflict with new grammar | Medium | Low | PR 4 migrates verify-code's pointers to the new grammar; interim state is acceptable since verify-code is last. |
+| Breaking change to downstream tooling depending on the legacy `ERROR:` gate string | **Low** | Low | Resolved open question — no downstream consumer outside the SDLC depends on it. FR5 permits rewording. |
+
+---
+
+## Open Questions
+
+None — both Phase-1 open questions were resolved and codified in requirements.md (FR5, FR11).
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #138 | 2026-04-19 | Initial design |
+
+---
+
+## Validation Checklist
+
+- [x] Architecture follows existing project patterns (extends `verify-code`'s `checklists/` + `references/` split)
+- [x] All API/interface changes documented (audit-script modes, pointer grammar)
+- [x] No database/storage changes (N/A — plugin-internal markdown refactor)
+- [x] State management approach clear (N/A — content lives in committed files only)
+- [x] UI components and hierarchy defined (N/A — no UI)
+- [x] Security considerations addressed
+- [x] Performance impact analyzed
+- [x] Testing strategy defined
+- [x] Alternatives considered and documented
+- [x] Risks identified with mitigations

--- a/specs/feature-refactor-skill-md-progressive-disclosure/feature.gherkin
+++ b/specs/feature-refactor-skill-md-progressive-disclosure/feature.gherkin
@@ -1,0 +1,132 @@
+# File: specs/feature-refactor-skill-md-progressive-disclosure/feature.gherkin
+#
+# Generated from: specs/feature-refactor-skill-md-progressive-disclosure/requirements.md
+# Issue: #138
+
+Feature: Refactor SKILL.md via Progressive Disclosure
+  As a nmg-sdlc plugin maintainer and Claude Code agent invoking these skills
+  I want every SKILL.md body under 300 lines with shared and variant content in references/
+  So that skills trigger faster with less context bloat and duplicated content lives in one place
+
+  Background:
+    Given the nmg-sdlc plugin at `plugins/nmg-sdlc/`
+    And the refactor described in issue #138 has shipped to main
+
+  # --- AC1: Size targets ---
+
+  Scenario: Every SKILL.md fits within its size target
+    Given the nmg-sdlc plugin after the refactor ships
+    When `wc -l plugins/nmg-sdlc/skills/*/SKILL.md` is run
+    Then every file reports at most 300 lines
+    And draft-issue/SKILL.md is at most 300 lines
+    And upgrade-project/SKILL.md is at most 250 lines
+    And write-spec/SKILL.md is at most 250 lines
+    And onboard-project/SKILL.md is at most 280 lines
+    And start-issue/SKILL.md is at most 220 lines
+    And verify-code/SKILL.md is at most 220 lines
+    And run-retro/SKILL.md is at most 180 lines
+    And open-pr/SKILL.md is at most 180 lines
+    And write-code/SKILL.md is at most 180 lines
+
+  # --- AC2: Zero observable change via exercise testing ---
+
+  Scenario: Refactored skill produces same artifacts as pre-refactor baseline
+    Given a refactored skill and a known-good project fixture under `scripts/__fixtures__/skill-exercise/`
+    When the skill is invoked end-to-end against the fixture via the exercise-test harness
+    Then deterministic artifacts are byte-equivalent to the pre-refactor baseline
+    And model-authored artifacts pass the rubric at `scripts/__fixtures__/skill-exercise/rubrics/{skill}.md`
+
+  # --- AC3: Shared content lives once ---
+
+  Scenario: Shared content appears in exactly one file
+    Given the six cross-skill shared references
+    When `grep -r` is run plugin-wide for the characteristic phrases of each shared block
+    Then `legacy-layout-gate.md` content appears only in `plugins/nmg-sdlc/references/legacy-layout-gate.md`
+    And `unattended-mode.md` content appears only in `plugins/nmg-sdlc/references/unattended-mode.md`
+    And `feature-naming.md` content appears only in `plugins/nmg-sdlc/references/feature-naming.md`
+    And `versioning.md` content appears only in `plugins/nmg-sdlc/references/versioning.md`
+    And `steering-schema.md` content appears only in `plugins/nmg-sdlc/references/steering-schema.md`
+    And `spec-frontmatter.md` content appears only in `plugins/nmg-sdlc/references/spec-frontmatter.md`
+    And every consuming SKILL.md contains a single named pointer to the shared file
+
+  # --- AC4: Slash-command surface unchanged ---
+
+  Scenario: The set of slash commands is identical after the refactor
+    Given the plugin's slash-command surface before the refactor
+    When the slash-command surface is enumerated from every post-refactor SKILL.md
+    Then the set of commands is identical — no additions, removals, or renames
+
+  # --- AC5: Frontmatter byte-identical ---
+
+  Scenario: Frontmatter is byte-identical for every skill
+    Given any skill's frontmatter before the refactor
+    When the pre- and post-refactor frontmatter blocks are diffed
+    Then `description` is byte-identical
+    And `allowed-tools` is byte-identical
+    And `model` is byte-identical
+    And `effort` is byte-identical
+    And `argument-hint` is byte-identical
+    And only body content below the frontmatter has moved
+
+  # --- AC6: Inventory audit passes deterministically ---
+
+  Scenario: Audit script reports zero unmapped inventory items
+    Given the committed `scripts/skill-inventory.baseline.json`
+    When `node scripts/skill-inventory-audit.mjs --check` runs in CI on a refactor PR
+    Then the exit code is 0
+    And every inventory item maps to exactly one destination in the refactored layout
+
+  Scenario: Audit script detects silent content loss
+    Given the `scripts/__fixtures__/audit-canary/bad/` fixture with a deliberately dropped item
+    When `node scripts/skill-inventory-audit.mjs --check` runs against the bad fixture
+    Then the exit code is 1
+    And stderr names the unmapped inventory item
+
+  Scenario: Baseline freshness check detects stale baseline
+    Given a PR that touches `plugins/nmg-sdlc/skills/draft-issue/SKILL.md`
+    And the committed baseline has drifted in files unrelated to the PR
+    When the baseline-freshness diff runs in CI
+    Then the workflow fails with a message naming the stale files
+
+  # --- AC7: Uniform pointer grammar ---
+
+  Scenario: Every pointer from a SKILL.md to a reference file matches the uniform grammar
+    Given any pointer from a SKILL.md to a reference file
+    When the pointer line is inspected
+    Then it matches the regex `^Read \`(\.\./\.\./)?references/[^\`]+\.md\` when `
+    And the reference path is in backticks
+    And the triggering condition is stated in the same sentence after `when`
+
+  # --- AC8: Reference-file budget ---
+
+  Scenario: Per-skill references directory stays within budget
+    Given any skill's directory under `plugins/nmg-sdlc/skills/`
+    When the per-skill `references/` directory is listed
+    Then it contains at most 5 files
+    And any reference file longer than 300 lines has a table of contents in its first 30 lines
+
+  # --- AC9: Shared-reference normative fidelity ---
+
+  Scenario: Shared references preserve the normative intent of each consumer
+    Given any shared reference file under `plugins/nmg-sdlc/references/`
+    When its content is compared against the pre-refactor SKILL.md passages it consolidates
+    Then no consuming skill has lost a directive
+    And no consuming skill has gained an unintended directive
+    And no directive has been rewritten to change its operational meaning
+    And wording unifications across consumers preserve semantics
+
+  # --- AC10: Claude Code GitHub App review workflow ---
+
+  Scenario: Claude Code GitHub App review runs on every PR
+    Given the Claude Code GitHub App is installed on the Nunley-Media-Group org with access to this repo
+    And `.github/workflows/claude-review.yml` has shipped in PR 1
+    When a pull request is opened or updated
+    Then the workflow invokes `anthropics/claude-code-action@v1`
+    And Claude posts an automated review comment on the PR
+    And the review reads the repo's `CLAUDE.md` and steering docs for context
+
+  Scenario: Claude Code responds to @claude mentions in PR comments
+    Given `.github/workflows/claude-review.yml` is active
+    When a comment containing `@claude` is posted on a PR or issue
+    Then the workflow fires
+    And Claude responds to the comment thread

--- a/specs/feature-refactor-skill-md-progressive-disclosure/requirements.md
+++ b/specs/feature-refactor-skill-md-progressive-disclosure/requirements.md
@@ -1,0 +1,278 @@
+# Requirements: Refactor SKILL.md via Progressive Disclosure
+
+**Issues**: #138
+**Date**: 2026-04-19
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## User Story
+
+**As a** nmg-sdlc plugin maintainer and as a Claude Code agent invoking these skills,
+**I want** every SKILL.md body to fit inside Anthropic's progressive-disclosure guidance (≤ 300 lines) with variant- and cross-skill-shared content extracted into `references/` loaded on demand,
+**So that** skills trigger faster and with less context bloat, duplicated content is maintained in one place, and skill bodies stay focused on the trigger + workflow skeleton rather than every edge case and variant.
+
+---
+
+## Background
+
+Anthropic's skill-authoring guidance (surfaced via the `skill-creator` skill) targets SKILL.md bodies under 500 lines and pushes variant-specific or conditionally-loaded content into `references/`. Several nmg-sdlc skills have outgrown that target substantially — `draft-issue` is 1087 lines, `upgrade-project` is 572, `write-spec` is 516. `verify-code` already demonstrates the split in-repo with its `checklists/` + `references/` layout; this issue extends the pattern plugin-wide and additionally extracts content that is duplicated across skills into shared references under `plugins/nmg-sdlc/references/`.
+
+Baseline line counts captured at issue authoring time:
+
+| Skill | Lines |
+|-------|-------|
+| draft-issue | 1087 |
+| upgrade-project | 572 |
+| write-spec | 516 |
+| onboard-project | 473 |
+| start-issue | 406 |
+| verify-code | 379 |
+| run-retro | 307 |
+| open-pr | 293 |
+| write-code | 218 |
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Every SKILL.md Fits Within Its Size Target
+
+**Given** the nmg-sdlc plugin after this refactor ships
+**When** `wc -l plugins/nmg-sdlc/skills/*/SKILL.md` is run
+**Then** every file reports ≤ 300 lines and each per-skill target is met:
+
+| Skill | Target |
+|-------|--------|
+| draft-issue | ≤ 300 |
+| upgrade-project | ≤ 250 |
+| write-spec | ≤ 250 |
+| onboard-project | ≤ 280 |
+| start-issue | ≤ 220 |
+| verify-code | ≤ 220 |
+| run-retro | ≤ 180 |
+| open-pr | ≤ 180 |
+| write-code | ≤ 180 |
+
+### AC2: Zero Observable Behavior Change (Exercise Testing)
+
+**Given** a refactored skill and a known-good project fixture
+**When** the skill is invoked end-to-end against the fixture via `/verify-code`'s exercise-testing path (plugin-scoped skills)
+**Then** it produces artifacts that are byte-equivalent (deterministic outputs) or spec-equivalent (model-authored outputs graded against a rubric) to the pre-refactor baseline captured on the same fixture.
+
+### AC3: Shared Content Lives in Exactly One Place
+
+**Given** the six cross-skill references listed below
+**When** `grep -r` is run plugin-wide for the characteristic phrases of each
+**Then** each block of duplicated content appears in exactly one file under `plugins/nmg-sdlc/references/`, and every consuming SKILL.md contains a single named pointer to that file with the triggering condition stated explicitly.
+
+| Shared reference | Consumed by |
+|------------------|-------------|
+| `legacy-layout-gate.md` | 8 pipeline skills |
+| `unattended-mode.md` | every pipeline skill |
+| `feature-naming.md` | draft-issue, start-issue, write-spec, verify-code, open-pr |
+| `versioning.md` | open-pr, draft-issue |
+| `steering-schema.md` | onboard-project, write-spec, verify-code, open-pr |
+| `spec-frontmatter.md` | write-spec, verify-code, run-retro |
+
+### AC4: Slash-Command Surface Unchanged
+
+**Given** the plugin before and after the refactor
+**When** the slash-command surface is enumerated from every SKILL.md (by collecting the skill name from each SKILL.md path and cross-checking frontmatter `description`)
+**Then** the set of commands is identical — no additions, removals, or renames.
+
+### AC5: Frontmatter Byte-Identical
+
+**Given** any skill's frontmatter before and after the refactor
+**When** the frontmatter blocks are diffed
+**Then** `description`, `allowed-tools`, `model`, `effort`, and `argument-hint` are byte-identical; only body content below the frontmatter moves.
+
+### AC6: Content-Inventory Audit Passes Deterministically
+
+**Given** a pre-refactor content inventory of each SKILL.md (every Input/Process/Output/Human-Review-Gate/unattended-mode clause enumerated as discrete inventory items)
+**When** an automated audit script checks the inventory against the refactored SKILL.md body plus its `references/` files
+**Then** every inventory item maps to exactly one destination, and any intentional removal is listed in the PR body with justification. The audit is a deterministic grep-based check, not a read-through — it runs in CI on the refactor PRs and fails the build on unmapped items.
+
+### AC7: Pointer Grammar Is Explicit and Uniform
+
+**Given** any pointer from a SKILL.md to a reference file
+**When** the pointer line is inspected
+**Then** it follows the shape `Read `references/{name}.md` when {triggering-condition}` — the reference path is in backticks, the triggering condition is stated in the same sentence, and each SKILL.md uses the same phrasing template so a reader can scan pointers consistently.
+
+### AC8: Reference-File Budget Per Skill
+
+**Given** any skill's directory after the refactor
+**When** the per-skill `references/` directory is listed
+**Then** it contains ≤ 5 reference files, and any reference file > 300 lines includes a table of contents in its first 30 lines.
+
+### AC9: Shared-Reference Normative Fidelity
+
+**Given** any shared reference file under `plugins/nmg-sdlc/references/`
+**When** its content is compared against the pre-refactor SKILL.md passages it consolidates
+**Then** the normative intent of every consuming skill is preserved — no consumer loses a directive, gains an unintended directive, or sees a directive rewritten to change its operational meaning. Wording may be unified across consumers; semantics may not drift.
+
+### AC10: Claude Code GitHub App Review Workflow Is Enabled
+
+**Given** the Claude Code GitHub App is already installed on the Nunley-Media-Group org with access to this repo
+**When** PR 1 ships
+**Then** a `.github/workflows/claude-review.yml` workflow runs `anthropics/claude-code-action@v1` on every PR (on `opened` and `synchronize`) and on issue-comment events that contain `@claude`, so every PR — including the subsequent refactor PRs in this effort — receives an automated review that reads the repo's `CLAUDE.md` and steering docs.
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: Refactor SKILL.md via Progressive Disclosure
+
+  Scenario: Every SKILL.md fits within its size target
+    Given the nmg-sdlc plugin after this refactor ships
+    When `wc -l plugins/nmg-sdlc/skills/*/SKILL.md` is run
+    Then every file reports ≤ 300 lines and each per-skill target is met
+
+  Scenario: Zero observable behavior change via exercise testing
+    Given a refactored skill and a known-good project fixture
+    When the skill is invoked end-to-end against the fixture
+    Then artifacts match the pre-refactor baseline byte-equivalent or spec-equivalent
+
+  Scenario: Shared content lives in exactly one place
+    Given the six cross-skill references
+    When `grep -r` is run plugin-wide for their characteristic phrases
+    Then each block appears in exactly one file under `plugins/nmg-sdlc/references/`
+
+  Scenario: Slash-command surface unchanged
+    Given the plugin before and after the refactor
+    When the slash-command surface is enumerated
+    Then the set of commands is identical
+
+  Scenario: Frontmatter byte-identical
+    Given any skill's frontmatter before and after the refactor
+    When the frontmatter blocks are diffed
+    Then all declared fields are byte-identical
+
+  Scenario: Content-inventory audit passes deterministically
+    Given a pre-refactor content inventory of each SKILL.md
+    When the audit script runs in CI
+    Then every inventory item maps to exactly one destination with no unmapped items
+
+  Scenario: Pointer grammar is explicit and uniform
+    Given any pointer from a SKILL.md to a reference file
+    When the pointer line is inspected
+    Then it follows `Read ``references/{name}.md`` when {triggering-condition}`
+
+  Scenario: Reference-file budget per skill
+    Given any skill's directory after the refactor
+    When the per-skill `references/` directory is listed
+    Then it contains ≤ 5 files, and any file > 300 lines has a TOC
+
+  Scenario: Shared-reference normative fidelity
+    Given any shared reference file
+    When its content is compared against the passages it consolidates
+    Then the normative intent of every consuming skill is preserved
+
+  Scenario: Claude Code GitHub App review workflow is enabled
+    Given the Claude Code GitHub App is already installed on the org
+    When PR 1 ships
+    Then `.github/workflows/claude-review.yml` runs on every PR and on @claude comments
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR1 | Create `plugins/nmg-sdlc/references/` with the 6 shared reference files: `legacy-layout-gate.md`, `unattended-mode.md`, `feature-naming.md`, `versioning.md`, `steering-schema.md`, `spec-frontmatter.md`. | Must |
+| FR2 | Refactor `draft-issue` to ≤ 300 lines by extracting multi-issue pipeline, Claude Design URL ingestion, interview depth, feature-vs-bug templates, and examples into per-skill `references/`. | Must |
+| FR3 | Refactor `upgrade-project` (≤ 250), `write-spec` (≤ 250), `onboard-project` (≤ 280). | Must |
+| FR4 | Refactor `start-issue` (≤ 220), `verify-code` (≤ 220), `run-retro` (≤ 180), `open-pr` (≤ 180), `write-code` (≤ 180). | Must |
+| FR5 | Soften rigid `ERROR:` / `MUST` / `NEVER` blocks with reasoning-first prose. Applies to the legacy-layout gate wording as well — no downstream parser depends on the current `ERROR:` prefix, so the message may be freely reworded. | Should |
+| FR6 | Collapse redundant "When to Use" / "Prerequisites" / "Next step" boilerplate; frontmatter `description:` already carries triggering. | Should |
+| FR7 | Each pointer from a SKILL.md to a reference file states the triggering condition explicitly and follows the uniform pointer grammar defined in AC7. | Must |
+| FR8 | Per-skill reference-file count ≤ 5; reference files > 300 lines include a TOC in the first 30 lines. | Should |
+| FR9 | Version bump to 1.53.0 (minor) with CHANGELOG entry naming the refactor pattern and line-count reductions per skill. Update both `plugins/nmg-sdlc/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. | Must |
+| FR10 | Roll out in 4 PRs: (1) additive shared references, (2) `draft-issue` pilot, (3) `write-spec` + `onboard-project` + `upgrade-project`, (4) remainder. | Could |
+| FR11 | Ship a permanent content-inventory audit script under `scripts/` (supporting AC6) that runs locally and in CI on every PR touching SKILL.md. Commit a baseline inventory file with this refactor; re-baseline only on intentional content removals documented in the PR body. | Must |
+| FR12 | Update `steering/structure.md` to document the new `references/` layer (plugin-shared + per-skill) in the layer-architecture diagram. | Should |
+| FR13 | Update `README.md` only if the refactor changes how users interact with the plugin; if interaction surface is unchanged (per AC4/AC5), no README update is required. | Must |
+| FR14 | Add `.github/workflows/claude-review.yml` invoking `anthropics/claude-code-action@v1` on `pull_request` (`opened`, `synchronize`) and on `issue_comment` events containing `@claude`. Ship in PR 1 so every subsequent refactor PR receives an automated review. | Must |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Every refactored SKILL.md triggers against `skill-creator`-style descriptions no slower than the pre-refactor baseline; body-size reduction should improve triggering latency but must not regress it. |
+| **Reliability** | The plugin loads without errors on Claude Code versions currently in the plugin's supported range. Missing reference files referenced from a SKILL.md must fail loudly (not silently skip). |
+| **Maintainability** | Duplication across SKILL.md bodies is eliminated for the six shared references. Future edits to shared content touch exactly one file. |
+| **Observability** | The content-inventory audit script prints a diff of inventory items → destinations so reviewers can see coverage at a glance. |
+| **Platforms** | No new platform assumptions. Reference files are plain Markdown; audit script follows `tech.md` conventions (Node built-ins or POSIX shell only). |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- [x] Existing `verify-code` `checklists/` + `references/` layout (precedent)
+- [x] Existing steering documents (`steering/structure.md` will be updated per FR12)
+
+### External Dependencies
+- None. Refactor is entirely plugin-internal.
+
+### Blocked By
+- None.
+
+---
+
+## Out of Scope
+
+- No new skills.
+- No changes to `scripts/sdlc-runner.mjs` or any runner behavior.
+- No changes to `.claude/unattended-mode` semantics.
+- No changes to skill frontmatter (`model`, `effort`, `allowed-tools`, `description`, `argument-hint`).
+- No slash-command renames, additions, or removals.
+- No changes to retrospective semantics or the `architecture-reviewer` agent.
+- No migration tooling for user projects — this is entirely plugin-internal.
+- No changes to existing templates under `plugins/nmg-sdlc/skills/*/templates/` beyond moving content between a skill's SKILL.md and its `references/`.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Total SKILL.md line count | ≥ 50% reduction plugin-wide | Sum of `wc -l plugins/nmg-sdlc/skills/*/SKILL.md` before vs after |
+| Per-skill targets met | 9 of 9 skills at or below their AC1 line target | Post-refactor `wc -l` audit |
+| Content-inventory coverage | 100% of inventory items mapped | Audit script exit code + printed diff |
+| Shared-content duplication | Zero duplication of the 6 shared blocks | `grep -r` for characteristic phrases in each block |
+| Exercise-test pass rate | 100% of refactored skills pass exercise tests | `/verify-code` exercise outputs match pre-refactor baseline |
+
+---
+
+## Open Questions
+
+- [x] ~~Is the content-inventory audit script one-shot or permanent?~~ **Resolved 2026-04-19: permanent.** Codified in FR11.
+- [x] ~~Does FR5 apply to the legacy-layout gate's exact `ERROR:` string?~~ **Resolved 2026-04-19: yes, reword freely.** No downstream parser depends on it outside the SDLC itself. Codified in FR5.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #138 | 2026-04-19 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements (AC6 references "audit script" as a capability, not a specific implementation)
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases and error states are specified (AC9 covers semantic drift; NFR-Reliability covers missing-reference failure)
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented

--- a/specs/feature-refactor-skill-md-progressive-disclosure/tasks.md
+++ b/specs/feature-refactor-skill-md-progressive-disclosure/tasks.md
@@ -1,0 +1,401 @@
+# Tasks: Refactor SKILL.md via Progressive Disclosure
+
+**Issues**: #138
+**Date**: 2026-04-19
+**Status**: Planning
+**Author**: Rich Nunley
+
+---
+
+## Summary
+
+The 5 phases below map 1:1 to the 4-PR rollout from the design, with Phase 5 (Testing) threaded across every PR as exercise tests and the BDD feature file.
+
+| Phase | Tasks | Status | PR |
+|-------|-------|--------|----|
+| 1: Setup (Additive Infrastructure) | 8 | [ ] | PR 1 |
+| 2: Pilot Refactor (draft-issue) | 4 | [ ] | PR 2 |
+| 3: Bulk Refactor (3 skills) | 3 | [ ] | PR 3 |
+| 4: Remainder Refactor + Release | 7 | [ ] | PR 4 |
+| 5: Testing (BDD + Exercise Suite) | 3 | [ ] | threaded |
+| **Total** | **25** | | |
+
+> **Skill-edit authoring note:** `steering/structure.md` lists "Skills must be authored via `/skill-creator`" as an architectural invariant. For this content-moving refactor, each `SKILL.md` edit task routes through `/skill-creator` per the invariant; the frontmatter is unchanged (AC5), so the `/skill-creator` session focuses on body restructuring. If `/skill-creator`'s interview-driven flow becomes impractical at scale, the implementer may hand-edit with a PR-body note documenting the exception — the architectural invariant is a floor, not a ceiling for bulk mechanical moves.
+
+---
+
+## Phase 1: Setup (Additive Infrastructure) — PR 1
+
+### T001: Create Plugin-Shared References Directory with 6 Files
+
+**File(s)**: `plugins/nmg-sdlc/references/legacy-layout-gate.md`, `plugins/nmg-sdlc/references/unattended-mode.md`, `plugins/nmg-sdlc/references/feature-naming.md`, `plugins/nmg-sdlc/references/versioning.md`, `plugins/nmg-sdlc/references/steering-schema.md`, `plugins/nmg-sdlc/references/spec-frontmatter.md`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] All 6 files exist with content consolidated from the consuming skills per the design's "Shared-Reference Contents" table
+- [ ] Each file has a TOC in its first 30 lines if it exceeds 300 lines (AC8)
+- [ ] The legacy-layout-gate message is reworded reasoning-first per FR5 (no `ERROR:` prefix required)
+- [ ] No SKILL.md files are edited in this task — the references are additive
+
+**Notes**: Consuming SKILL.md files are not updated yet; they continue to inline their existing copies until later phases update their pointers. This keeps PR 1 purely additive.
+
+### T002: Create Content-Inventory Audit Script
+
+**File(s)**: `scripts/skill-inventory-audit.mjs`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] Zero external dependencies (Node built-ins only, per `steering/tech.md`)
+- [ ] Supports `--baseline`, `--check` (default), `--diff`, and `--output <path>` modes per design
+- [ ] Extracts inventory items per the extraction rules in design's "Inventory Extraction Rules"
+- [ ] Normalizes and hashes each item (SHA-1, 12-char prefix ID)
+- [ ] Writes JSON in the data shape from design
+- [ ] `--check` exits 0 on clean scan, 1 on unmapped items, with human-readable stderr
+
+### T003: Create Canary Fixtures and Jest Tests for Audit Script
+
+**File(s)**: `scripts/__fixtures__/audit-canary/good/SKILL.md`, `scripts/__fixtures__/audit-canary/good/references/*.md`, `scripts/__fixtures__/audit-canary/bad/SKILL.md`, `scripts/__tests__/skill-inventory-audit.test.js`
+**Type**: Create
+**Depends**: T002
+**Acceptance**:
+- [ ] `good/` fixture passes `--check` (exit 0)
+- [ ] `bad/` fixture fails `--check` (exit 1) — contains a deliberately dropped inventory item
+- [ ] Jest unit tests cover: extraction rules per heading type, normalization idempotence, hash stability, mode flag behavior, exit codes, normalization-collision handling
+- [ ] Jest integration test round-trips the baseline against a temporary clone of the fixture
+- [ ] `cd scripts && npm test` passes locally
+
+### T004: Generate and Commit Pre-Refactor Baseline
+
+**File(s)**: `scripts/skill-inventory.baseline.json`
+**Type**: Create
+**Depends**: T002
+**Acceptance**:
+- [ ] Run `node scripts/skill-inventory-audit.mjs --baseline` against current checkout
+- [ ] Commit the generated JSON verbatim — no hand edits
+- [ ] `node scripts/skill-inventory-audit.mjs --check` reports zero drift against the committed baseline
+- [ ] Baseline file is deterministic (same input produces identical JSON across runs; `generated_at` timestamp is the only non-deterministic field — document this in the JSON schema)
+
+### T005: Create GitHub Actions Workflow for Audit Enforcement
+
+**File(s)**: `.github/workflows/skill-inventory-audit.yml`
+**Type**: Create
+**Depends**: T002, T003, T004
+**Acceptance**:
+- [ ] Workflow triggers on PRs touching any `plugins/nmg-sdlc/skills/**/SKILL.md`, any `plugins/nmg-sdlc/**/references/**`, or `scripts/skill-inventory.baseline.json`
+- [ ] Job steps: (1) run canary fixture tests, (2) run `--check` against the committed baseline, (3) run baseline-freshness diff (fresh baseline vs committed, ignoring PR-touched files), (4) lint PR body for `### Inventory Removals` heading when baseline file is modified
+- [ ] All steps fail the workflow on non-zero exit — no `continue-on-error`
+- [ ] Workflow is a required status check on `main` (documented in PR description for repo admin to enable in branch protection)
+
+### T006: Wire Audit into /verify-code Verification Gates
+
+**File(s)**: `steering/tech.md` (Verification Gates table), `plugins/nmg-sdlc/skills/verify-code/SKILL.md` (unchanged in body; this task only adds the gate declaration referenced by `tech.md`)
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `steering/tech.md`'s Verification Gates table has a new row: Gate="Skill inventory audit", Condition="Any `plugins/nmg-sdlc/skills/**/SKILL.md` or `plugins/nmg-sdlc/**/references/**` changed", Action="`node scripts/skill-inventory-audit.mjs --check`", Pass Criteria="Exit code 0"
+- [ ] No other `tech.md` content changes beyond this row
+- [ ] `verify-code`'s Verification Gates section is re-read unchanged — the gate comes from `tech.md` so verify-code inherits it automatically
+
+### T007: Add Claude Code GitHub App Review Workflow
+
+**File(s)**: `.github/workflows/claude-review.yml`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] Workflow invokes `anthropics/claude-code-action@v1`
+- [ ] Triggers: `pull_request` on `opened` and `synchronize`, plus `issue_comment` on `created` gated by `contains(github.event.comment.body, '@claude')`
+- [ ] Permissions set: `contents: read`, `pull-requests: write`, `issues: write`
+- [ ] Uses org-level `ANTHROPIC_API_KEY` secret (already provisioned — no repo secret to add)
+- [ ] Concurrency group keyed by PR/issue number with `cancel-in-progress: true`
+- [ ] Checkout step uses `fetch-depth: 0` so Claude can read full git history
+- [ ] On PR 1 itself, the workflow posts an automated review (self-dogfood) — verify before requesting human review
+
+### T008: PR 1 Smoke Test
+
+**File(s)**: *(no file changes)*
+**Type**: Verify
+**Depends**: T001, T002, T003, T004, T005, T006, T007
+**Acceptance**:
+- [ ] One skill is loaded via `claude --plugin-dir ./plugins/nmg-sdlc` locally and its existing behavior is unchanged (no SKILL.md edits have shipped yet — this is a pre-refactor sanity check)
+- [ ] CI workflow runs green on a trial PR containing only T001–T007
+- [ ] Audit baseline round-trips without drift
+- [ ] Claude Code review posts a comment on PR 1
+
+---
+
+## Phase 2: Pilot Refactor (draft-issue) — PR 2
+
+### T009: Extract draft-issue Variant Content into Per-Skill References
+
+**File(s)**: `plugins/nmg-sdlc/skills/draft-issue/references/multi-issue.md`, `plugins/nmg-sdlc/skills/draft-issue/references/design-url.md`, `plugins/nmg-sdlc/skills/draft-issue/references/interview-depth.md`, `plugins/nmg-sdlc/skills/draft-issue/references/feature-template.md`, `plugins/nmg-sdlc/skills/draft-issue/references/bug-template.md`
+**Type**: Create
+**Depends**: T001 (shared references exist)
+**Acceptance**:
+- [ ] All 5 files exist with content lifted from `draft-issue/SKILL.md`
+- [ ] Each file < 300 lines, or has a TOC in its first 30 lines if larger (AC8)
+- [ ] ≤ 5 files total in `draft-issue/references/` (AC8 budget)
+- [ ] Normative intent of each extracted passage is preserved (AC9)
+
+### T010: Refactor draft-issue/SKILL.md to ≤ 300 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/draft-issue/SKILL.md`
+**Type**: Modify
+**Depends**: T001, T009
+**Acceptance**:
+- [ ] `wc -l plugins/nmg-sdlc/skills/draft-issue/SKILL.md` reports ≤ 300
+- [ ] Frontmatter is byte-identical to pre-refactor (AC5) — verify with `diff` of extracted frontmatter blocks
+- [ ] Every pointer follows the AC7 grammar: `Read \`references/{name}.md\` when {trigger}.` (or `../../references/` for shared references)
+- [ ] Slash command surface unchanged (AC4)
+- [ ] Shared-reference pointers target `../../references/{name}.md`; per-skill pointers target `references/{name}.md`
+- [ ] No duplication of shared-reference content remains in the body (AC3)
+
+### T011: Regenerate Baseline with Inventory-Removal Justification
+
+**File(s)**: `scripts/skill-inventory.baseline.json`
+**Type**: Modify
+**Depends**: T009, T010
+**Acceptance**:
+- [ ] Run `--diff` to preview the expected destination changes
+- [ ] Run `--baseline` to regenerate the file
+- [ ] Any items genuinely removed from the plugin are listed under a `### Inventory Removals` heading in PR 2's body, with rationale per item
+- [ ] Post-regeneration, `--check` passes with zero drift
+
+### T012: Exercise Test — draft-issue Against Fixture
+
+**File(s)**: `scripts/__fixtures__/skill-exercise/draft-issue/`, `scripts/__fixtures__/skill-exercise/rubrics/draft-issue.md`, `scripts/skill-exercise-runner.mjs`
+**Type**: Create
+**Depends**: T010
+**Acceptance**:
+- [ ] Fixture project scaffolded per `steering/structure.md`'s "Test Project Scaffolding" (steering/, src/, README, .gitignore, git-initialized)
+- [ ] Rubric describes the deterministic and rubric-graded output properties
+- [ ] `scripts/skill-exercise-runner.mjs` spawns `claude -p` with the Agent SDK `canUseTool` callback pattern from `steering/tech.md`
+- [ ] Exercise run against refactored draft-issue produces artifacts that pass the rubric compared to a pre-refactor baseline captured on main
+- [ ] Deterministic artifacts (slash-command enumeration, frontmatter, file paths written) are byte-equivalent between pre- and post-refactor runs (AC2)
+
+---
+
+## Phase 3: Bulk Refactor (3 skills) — PR 3
+
+### T013: Refactor write-spec to ≤ 250 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/write-spec/SKILL.md`, `plugins/nmg-sdlc/skills/write-spec/references/discovery.md`, `plugins/nmg-sdlc/skills/write-spec/references/amendment-mode.md`, `plugins/nmg-sdlc/skills/write-spec/references/defect-variant.md`, `plugins/nmg-sdlc/skills/write-spec/references/review-gates.md`
+**Type**: Create + Modify
+**Depends**: T001, T010 (pilot pattern established)
+**Acceptance**:
+- [ ] `wc -l` ≤ 250 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Every pointer matches AC7 grammar
+- [ ] Shared-reference pointers present for every duplicated block (legacy-layout-gate, unattended-mode, feature-naming, spec-frontmatter — see design's Shared-Reference Contents table)
+- [ ] Exercise test passes against fixture; baseline regenerated and justified
+
+### T014: Refactor onboard-project to ≤ 280 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/onboard-project/SKILL.md`, `plugins/nmg-sdlc/skills/onboard-project/references/greenfield.md`, `plugins/nmg-sdlc/skills/onboard-project/references/brownfield.md`, `plugins/nmg-sdlc/skills/onboard-project/references/interview.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 280 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Every pointer matches AC7 grammar
+- [ ] Shared-reference pointers present for steering-schema and unattended-mode
+- [ ] Exercise test passes; baseline regenerated
+
+### T015: Refactor upgrade-project to ≤ 250 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/upgrade-project/SKILL.md`, `plugins/nmg-sdlc/skills/upgrade-project/references/detection.md`, `plugins/nmg-sdlc/skills/upgrade-project/references/migration-steps.md`, `plugins/nmg-sdlc/skills/upgrade-project/references/verification.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 250 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Every pointer matches AC7 grammar
+- [ ] Shared-reference pointers present for legacy-layout-gate and unattended-mode (upgrade-project is the one skill that *resolves* the gate, so its pointer semantics differ — document in the reference file itself)
+- [ ] Exercise test passes; baseline regenerated
+
+---
+
+## Phase 4: Remainder Refactor + Release — PR 4
+
+### T016: Refactor start-issue to ≤ 220 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/start-issue/SKILL.md`, `plugins/nmg-sdlc/skills/start-issue/references/dirty-tree.md`, `plugins/nmg-sdlc/skills/start-issue/references/milestone-selection.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 220 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Pointer grammar (AC7), shared-reference pointers (feature-naming, legacy-layout-gate, unattended-mode)
+- [ ] Exercise test passes
+
+### T017: Refactor verify-code to ≤ 220 Lines (Including Pointer-Grammar Migration)
+
+**File(s)**: `plugins/nmg-sdlc/skills/verify-code/SKILL.md`, `plugins/nmg-sdlc/skills/verify-code/references/autofix-loop.md`, `plugins/nmg-sdlc/skills/verify-code/references/defect-path.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 220 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Existing `[text](checklists/...)` and `[text](references/...)` pointers are migrated to the AC7 grammar (`Read \`checklists/...\` when ...`)
+- [ ] Shared-reference pointers added for legacy-layout-gate, unattended-mode, feature-naming, steering-schema, spec-frontmatter
+- [ ] Exercise test passes
+
+### T018: Refactor run-retro to ≤ 180 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/run-retro/SKILL.md`, `plugins/nmg-sdlc/skills/run-retro/references/learning-extraction.md`, `plugins/nmg-sdlc/skills/run-retro/references/transferability.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 180 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Shared-reference pointer added for spec-frontmatter
+- [ ] Exercise test passes
+
+### T019: Refactor open-pr to ≤ 180 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/open-pr/SKILL.md`, `plugins/nmg-sdlc/skills/open-pr/references/version-bump.md`, `plugins/nmg-sdlc/skills/open-pr/references/ci-monitoring.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 180 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Shared-reference pointers added for versioning, feature-naming, steering-schema, legacy-layout-gate, unattended-mode
+- [ ] Exercise test passes
+
+### T020: Refactor write-code to ≤ 180 Lines
+
+**File(s)**: `plugins/nmg-sdlc/skills/write-code/SKILL.md`, `plugins/nmg-sdlc/skills/write-code/references/plan-mode.md`, `plugins/nmg-sdlc/skills/write-code/references/resumption.md`
+**Type**: Create + Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `wc -l` ≤ 180 (AC1)
+- [ ] Frontmatter byte-identical (AC5)
+- [ ] Shared-reference pointers added for legacy-layout-gate, unattended-mode
+- [ ] Exercise test passes
+
+### T021: Update steering/structure.md to Document References Layer
+
+**File(s)**: `steering/structure.md`
+**Type**: Modify
+**Depends**: None (can run in parallel with T016–T020)
+**Acceptance**:
+- [ ] Project Layout tree shows `plugins/nmg-sdlc/references/` (plugin-shared)
+- [ ] Per-skill layout shows `references/` alongside existing `templates/` and `checklists/`
+- [ ] Layer Architecture diagram has a new row for "Plugin-shared references" and "Per-skill references" with their responsibilities
+- [ ] Naming Conventions section gains a row for "Reference directories" → `references/`
+- [ ] File Templates section gains a pointer-grammar example matching AC7
+
+### T022: Version Bump to 1.53.0 and CHANGELOG Entry
+
+**File(s)**: `plugins/nmg-sdlc/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `CHANGELOG.md`
+**Type**: Modify
+**Depends**: T016, T017, T018, T019, T020, T021
+**Acceptance**:
+- [ ] `plugin.json` version = `1.53.0`
+- [ ] `marketplace.json` plugin entry version = `1.53.0`
+- [ ] `metadata.version` in `marketplace.json` unchanged (plugin-version bump, not marketplace-collection bump)
+- [ ] CHANGELOG `[Unreleased]` items moved under `## [1.53.0] - 2026-04-19`
+- [ ] CHANGELOG entry names the refactor pattern and lists per-skill line-count reductions (before → after)
+- [ ] No other files modified in this commit
+
+---
+
+## Phase 5: Testing (threaded across PRs)
+
+### T023: Create feature.gherkin with All 10 Scenarios
+
+**File(s)**: `specs/feature-refactor-skill-md-progressive-disclosure/feature.gherkin`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] One scenario per AC (AC1–AC10)
+- [ ] Valid Gherkin syntax
+- [ ] Scenarios use concrete data (specific skill names, specific line counts from AC1)
+- [ ] Includes a Background for shared preconditions (plugin at `plugins/nmg-sdlc/`, refactor branch merged)
+
+### T024: Exercise-Test Harness for Full Plugin
+
+**File(s)**: `scripts/skill-exercise-runner.mjs` (extend from T012), `scripts/__fixtures__/skill-exercise/rubrics/*.md`
+**Type**: Modify + Create
+**Depends**: T012
+**Acceptance**:
+- [ ] Harness can exercise every refactored skill against its fixture with one CLI invocation
+- [ ] Rubric files exist for every skill refactored in PRs 2–4
+- [ ] Harness emits a pass/fail report per skill and aggregate counts
+- [ ] Deterministic-artifact checks and rubric-graded checks are reported separately
+
+### T025: Final Verification Pass — All ACs
+
+**File(s)**: *(no file changes)*
+**Type**: Verify
+**Depends**: T001–T024
+**Acceptance**:
+- [ ] AC1 met: every SKILL.md at its line target (structural check)
+- [ ] AC2 met: every refactored skill passes exercise test
+- [ ] AC3 met: `grep -r` confirms no duplication of the 6 shared blocks outside `plugins/nmg-sdlc/references/`
+- [ ] AC4 met: slash-command surface byte-identical (diff pre/post enumeration)
+- [ ] AC5 met: frontmatter byte-identical for every skill
+- [ ] AC6 met: audit `--check` passes; CI workflow green on every PR
+- [ ] AC7 met: every pointer matches the regex `^Read \`(\.\./\.\./)?references/[^\`]+\.md\` when `
+- [ ] AC8 met: per-skill `references/` count ≤ 5; TOC present on any file > 300 lines
+- [ ] AC9 met: reviewer sign-off that every shared-reference passage preserves the normative intent of every consumer
+- [ ] AC10 met: `.github/workflows/claude-review.yml` is present; Claude Code review posted on every refactor PR
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (PR 1)
+  T001 ──┬──▶ T009 (Phase 2)
+         ├──▶ T013, T014, T015 (Phase 3)
+         ├──▶ T016, T017, T018, T019, T020 (Phase 4)
+  T002 ──┬──▶ T003
+         ├──▶ T004
+         ├──▶ T005
+         └──▶ T006
+  T003, T004, T005, T006, T007 ──▶ T008
+
+Phase 2 (PR 2)
+  T001 ──▶ T009 ──▶ T010 ──▶ T011 ──▶ T012
+
+Phase 3 (PR 3) — three parallel tracks, each gated by T001 and following T010's pattern
+  T013 ─┐
+  T014 ─┤──▶ (PR 3 ready)
+  T015 ─┘
+
+Phase 4 (PR 4) — five parallel tracks plus T021 and T022
+  T016 ─┐
+  T017 ─┤
+  T018 ─┼──▶ T022 ──▶ (PR 4 ready)
+  T019 ─┤
+  T020 ─┘
+  T021 ─┘
+
+Phase 5 (threaded)
+  T023: runs as part of PR 1 (design artifact, not code)
+  T024: extends through PRs 2, 3, 4 as each skill is added
+  T025: gate for PR 4 merge
+```
+
+**Critical path**: T002 → T003 → T005 → T008 → T009 → T010 → T012 → T013 → T022 → T025
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #138 | 2026-04-19 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+- [x] Each task has single responsibility
+- [x] Dependencies correctly mapped
+- [x] Tasks can be completed independently within each PR given their dependencies
+- [x] Acceptance criteria are verifiable (line counts, byte-diffs, exit codes, regex matches)
+- [x] File paths reference actual project structure per `steering/structure.md`
+- [x] Test tasks included (T003 unit + canary, T008 PR 1 smoke, T012 pilot exercise, T023 BDD, T024 harness, T025 final)
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order


### PR DESCRIPTION
## Summary
- Adds BDD specification artifacts (requirements, design, tasks, feature.gherkin) for issue Nunley-Media-Group/nmg-sdlc#77 under `specs/feature-refactor-skill-md-progressive-disclosure/`
- Captures baseline line counts, per-skill size targets, 10 acceptance criteria, and 4-PR rollout plan
- Documents shared reference extraction plan (6 cross-skill references) and content-inventory audit approach

## Test plan
- [x] Spec files render correctly
- [x] No code changes — docs/spec-only PR