### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 1.71.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "5badc496628aeddb8a57834e13d2e07414d981d4"
+        "sha": "fd15cd75d082f73dd89b45efdd223c80da958258"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "1.69.0"
+      "x-version": "1.71.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `1.69.0` to `1.71.0`.
- Pin the current upstream `main` commit SHA so plugin installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed the manifest version and SHA match upstream `nmg-sdlc` `main`.
- [x] Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integrated SDLC plugin to version 1.71.0.
  * Refreshed the plugin source reference to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->