### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.0.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "fd15cd75d082f73dd89b45efdd223c80da958258"
+        "sha": "d675722dcba22d8f399cfbd1de709bccd6bfab19"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "1.71.0"
+      "x-version": "2.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `1.71.0` to `2.0.0`.
- Pin the current upstream `main` commit SHA so plugin installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed the manifest version and SHA match upstream `nmg-sdlc` `main`.
- [x] Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `nmg-sdlc` plugin to version 2.0.0 with its latest source revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->