### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.0.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "d675722dcba22d8f399cfbd1de709bccd6bfab19"
+        "sha": "aa98ce66fd77d389eaac90b5f90d8fe62e2feb4b"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "2.0.0"
+      "x-version": "2.0.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `2.0.0` to `2.0.1`.
- Pin the current upstream `main` commit SHA so plugin installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed the manifest version and SHA match upstream `nmg-sdlc` `main`.
- [x] Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `nmg-sdlc` plugin to a newer maintenance release.
  * Refreshed the plugin source reference to ensure the latest version is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->