### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.0.6

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "aa98ce66fd77d389eaac90b5f90d8fe62e2feb4b"
+        "sha": "a48c8573a0c544f064a392e5c97ef7e78b11d01f"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "2.0.1"
+      "x-version": "2.0.6"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `2.0.1` to `2.0.6`.
- Pin the current upstream `main` commit SHA so plugin installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed the manifest version and SHA match upstream `nmg-sdlc` `main`.
- [x] Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDLC tooling integration to the latest available version.
  * Includes maintenance improvements and compatibility updates with no changes to the product’s public features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->