### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.0.7

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "a48c8573a0c544f064a392e5c97ef7e78b11d01f"
+        "sha": "45a0230ba3aea9080e16f30fee464975b0171fb7"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "2.0.6"
+      "x-version": "2.0.7"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `2.0.6` to `2.0.7`.
- Pin the current upstream `main` commit SHA so plugin installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed the manifest version and SHA match upstream `nmg-sdlc` `main`.
- [x] Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the marketplace plugin integration to a newer maintenance release.
  * No new end-user features or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->