### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.0.9

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "21bbc5659b9dc54f4585309f5e9edfebe9a331a5"
+        "sha": "d39c0442bfc678220c0a9f49ccaa1b2d4440447b"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "2.0.8"
+      "x-version": "2.0.9"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `2.0.8` to `2.0.9`.
- Pin upstream `main` at `d39c0442bfc678220c0a9f49ccaa1b2d4440447b` so installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed `VERSION` and `.codex-plugin/plugin.json` both declare `2.0.9` at the pinned upstream SHA.
- [x] Confirmed upstream `refs/heads/main` resolves to the pinned SHA.
- [x] Ran `git diff --check`.