### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.0.10

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "d39c0442bfc678220c0a9f49ccaa1b2d4440447b"
+        "sha": "cb63b42ac4fbc941626eedb1441f429cbca4a320"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "2.0.9"
+      "x-version": "2.0.10"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the `nmg-sdlc` marketplace pointer from version `2.0.9` to `2.0.10`.
- Pin upstream `main` at `cb63b42ac4fbc941626eedb1441f429cbca4a320` so installs resolve reproducibly.

## Validation

- [x] Parsed `.agents/plugins/marketplace.json` successfully.
- [x] Confirmed `VERSION` and `.codex-plugin/plugin.json` both declare `2.0.10` at the pinned upstream SHA.
- [x] Confirmed upstream `refs/heads/main` resolves to the pinned SHA.
- [x] Ran `git diff --check`.