### PR TITLE
chore: sync nmg-sdlc marketplace pointer to 2.1.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,14 +10,14 @@
         "source": "url",
         "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
         "ref": "main",
-        "sha": "cb63b42ac4fbc941626eedb1441f429cbca4a320"
+        "sha": "7675f0e0c01d4b3d9fbcca379c8b9ec9a69bc892"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "x-version": "2.0.10"
+      "x-version": "2.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update the nmg-sdlc marketplace pointer from version 2.0.10 to 2.1.0.
- Pin upstream main at 7675f0e0c01d4b3d9fbcca379c8b9ec9a69bc892 so installs resolve reproducibly.
- Complete the protected-branch release after the repository-dispatch direct push was rejected.

## Validation

- [x] Parsed .agents/plugins/marketplace.json successfully.
- [x] Confirmed VERSION and .codex-plugin/plugin.json both declare 2.1.0 at the pinned upstream SHA.
- [x] Confirmed upstream refs/heads/main resolves to the pinned SHA.
- [x] Ran git diff --check.