### PR TITLE
Fix nmg-sdlc marketplace compatibility with Pi Plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "nmg-plugins",
+  "description": "Nunley Media Group plugins for structured software delivery",
+  "owner": {
+    "name": "Nunley Media Group"
+  },
+  "plugins": [
+    {
+      "name": "nmg-sdlc",
+      "description": "Stack-agnostic BDD spec-driven development toolkit",
+      "version": "2.1.0",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
+        "ref": "main",
+        "sha": "7675f0e0c01d4b3d9fbcca379c8b9ec9a69bc892"
+      },
+      "strict": false,
+      "skills": "./skills",
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.github/workflows/sync-nmg-sdlc-pointer.yml
+++ b/.github/workflows/sync-nmg-sdlc-pointer.yml
@@ -67,34 +67,39 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Update marketplace manifest
+      - name: Update marketplace manifests
         env:
           SHA: ${{ steps.metadata.outputs.sha }}
           VERSION: ${{ steps.metadata.outputs.version }}
         run: |
           set -euo pipefail
           node <<'NODE'
-          const fs = require('node:fs');
-          const path = '.agents/plugins/marketplace.json';
+          const fs = require("node:fs");
           const sha = process.env.SHA;
           const version = process.env.VERSION;
-          const manifest = JSON.parse(fs.readFileSync(path, 'utf8'));
-          const plugin = manifest.plugins?.find((entry) => entry.name === 'nmg-sdlc');
-
-          if (!plugin) {
-            throw new Error('marketplace is missing the nmg-sdlc plugin entry');
+          for (const path of [
+            ".agents/plugins/marketplace.json",
+            ".claude-plugin/marketplace.json",
+          ]) {
+            const manifest = JSON.parse(fs.readFileSync(path, "utf8"));
+            const plugin = manifest.plugins?.find((entry) => entry.name === "nmg-sdlc");
+            if (!plugin) {
+              throw new Error(`${path} is missing the nmg-sdlc plugin entry`);
+            }
+            plugin.source = {
+              source: "url",
+              url: "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
+              ref: "main",
+              sha,
+            };
+            if (path.startsWith(".agents/")) plugin["x-version"] = version;
+            else plugin.version = version;
+            fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
           }
-
-          plugin.source = {
-            source: 'url',
-            url: 'https://github.com/Nunley-Media-Group/nmg-sdlc.git',
-            ref: 'main',
-            sha,
-          };
-          plugin['x-version'] = version;
-
-          fs.writeFileSync(path, JSON.stringify(manifest, null, 2) + '\n');
           NODE
+
+      - name: Validate marketplace manifests
+        run: node scripts/validate-marketplace.mjs
 
       - name: Commit marketplace update
         env:
@@ -102,13 +107,15 @@ jobs:
           VERSION: ${{ steps.metadata.outputs.version }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- .agents/plugins/marketplace.json; then
+          if git diff --quiet -- \
+            .agents/plugins/marketplace.json \
+            .claude-plugin/marketplace.json; then
             echo "nmg-sdlc marketplace pointer already matches ${VERSION} (${SHA})."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .agents/plugins/marketplace.json
+          git add .agents/plugins/marketplace.json .claude-plugin/marketplace.json
           git commit -m "chore: sync nmg-sdlc marketplace pointer to ${VERSION}"
           git push origin HEAD:main

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -1,0 +1,28 @@
+name: Validate Marketplace
+
+on:
+  pull_request:
+    paths:
+      - ".agents/plugins/marketplace.json"
+      - ".claude-plugin/marketplace.json"
+      - "scripts/validate-marketplace.mjs"
+      - ".github/workflows/validate-marketplace.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".agents/plugins/marketplace.json"
+      - ".claude-plugin/marketplace.json"
+      - "scripts/validate-marketplace.mjs"
+      - ".github/workflows/validate-marketplace.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/validate-marketplace.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Codex plugin marketplace repository for Nunley Media Group. Each listed plugin l
 
 ```
 .agents/plugins/marketplace.json  — Codex marketplace index (Git-backed plugin entries)
+.claude-plugin/marketplace.json   — Claude-compatible index consumed by Pi plugin managers
 README.md                         — Public docs: how to add the marketplace, plugin pointers
 ```
 
@@ -23,8 +24,10 @@ When adding or removing a plugin:
      `{"source": {"source": "url", "url": "https://github.com/owner/name.git", "ref": "main"}}`
    - If the plugin lives in a subdirectory, use `source: "git-subdir"` with a `path`
    - Include `policy.installation`, `policy.authentication`, and `category` on every entry
-2. Update `README.md` to list the plugin and its source repo
-3. Open a PR — there is no marketplace-level CI yet
+2. Keep the matching entry in `.claude-plugin/marketplace.json` synchronized for Pi compatibility.
+3. Run `node scripts/validate-marketplace.mjs`.
+4. Update `README.md` to list the plugin and its source repo.
+5. Open a PR.
 
 Version bumps happen entirely in each plugin's own repo; this marketplace file only changes when a plugin is added, removed, renamed, or repointed to a different ref or URL.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nmg-plugins
 
-Codex plugin marketplace by Nunley Media Group.
+Codex- and Pi-compatible plugin marketplace by Nunley Media Group.
 
 ## Plugins
 
@@ -21,6 +21,18 @@ codex plugin install nmg-sdlc@nmg-plugins
 ```
 
 This marketplace uses Git-backed Codex entries, so each plugin can stay in its own repository. For private repos, ensure your Git credentials have read access to both the marketplace repo and the plugin repositories.
+
+### Pi
+
+Install a compatible Pi plugin manager, add this marketplace, then install nmg-sdlc:
+
+```text
+pi install npm:@nklisch/pi-plugins
+/plugins marketplace add Nunley-Media-Group/nmg-plugins
+/plugins add nmg-sdlc@nmg-plugins --scope user
+```
+
+The Claude-compatible marketplace index supplies Pi's root-repository source representation while the Codex index remains authoritative for Codex consumers.
 
 ## Updating
 

--- a/scripts/validate-marketplace.mjs
+++ b/scripts/validate-marketplace.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const CODEX_PATH = ".agents/plugins/marketplace.json";
+const CLAUDE_PATH = ".claude-plugin/marketplace.json";
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const CLAUDE_SOURCE_TYPES = new Set(["github", "url", "git-subdir", "npm"]);
+
+function readManifest(path) {
+  let value;
+  try {
+    value = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`${path} is not valid JSON: ${error.message}`);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${path} must contain a JSON object`);
+  }
+  if (typeof value.name !== "string" || !Array.isArray(value.plugins)) {
+    throw new Error(`${path} requires a string name and plugins array`);
+  }
+  return value;
+}
+
+function entriesByName(manifest, path) {
+  const entries = new Map();
+  for (const entry of manifest.plugins) {
+    if (!entry || typeof entry !== "object" || typeof entry.name !== "string") {
+      throw new Error(`${path} contains a plugin without a valid name`);
+    }
+    if (entries.has(entry.name)) {
+      throw new Error(`${path} contains duplicate plugin ${entry.name}`);
+    }
+    entries.set(entry.name, entry);
+  }
+  return entries;
+}
+
+function validatePinnedSource(source, path, pluginName) {
+  if (!source || typeof source !== "object" || Array.isArray(source)) {
+    throw new Error(`${path} plugin ${pluginName} requires an object source`);
+  }
+  if (source.ref !== "main") {
+    throw new Error(`${path} plugin ${pluginName} must pin ref main`);
+  }
+  if (typeof source.sha !== "string" || !SHA_PATTERN.test(source.sha)) {
+    throw new Error(`${path} plugin ${pluginName} must pin a full lowercase commit SHA`);
+  }
+}
+
+const codex = readManifest(CODEX_PATH);
+const claude = readManifest(CLAUDE_PATH);
+if (codex.name !== claude.name) {
+  throw new Error(`marketplace names differ: ${codex.name} != ${claude.name}`);
+}
+
+const codexEntries = entriesByName(codex, CODEX_PATH);
+const claudeEntries = entriesByName(claude, CLAUDE_PATH);
+for (const [name, codexEntry] of codexEntries) {
+  const claudeEntry = claudeEntries.get(name);
+  if (!claudeEntry) {
+    throw new Error(`${CLAUDE_PATH} is missing plugin ${name}`);
+  }
+  validatePinnedSource(codexEntry.source, CODEX_PATH, name);
+  validatePinnedSource(claudeEntry.source, CLAUDE_PATH, name);
+  if (!CLAUDE_SOURCE_TYPES.has(claudeEntry.source.source)) {
+    throw new Error(`${CLAUDE_PATH} plugin ${name} has unsupported source type ${claudeEntry.source.source}`);
+  }
+  for (const field of ["url", "ref", "sha"]) {
+    if (codexEntry.source[field] !== claudeEntry.source[field]) {
+      throw new Error(`plugin ${name} source.${field} differs between marketplace manifests`);
+    }
+  }
+  if (codexEntry["x-version"] !== claudeEntry.version) {
+    throw new Error(`plugin ${name} version differs between marketplace manifests`);
+  }
+  if (claudeEntry.strict !== false || claudeEntry.skills !== "./skills") {
+    throw new Error(`${CLAUDE_PATH} plugin ${name} must declare non-strict ./skills runtime metadata`);
+  }
+}
+for (const name of claudeEntries.keys()) {
+  if (!codexEntries.has(name)) {
+    throw new Error(`${CODEX_PATH} is missing plugin ${name}`);
+  }
+}
+
+console.log(`Validated ${codexEntries.size} synchronized Codex/Claude marketplace plugin(s).`);


### PR DESCRIPTION
## Summary

- add a Claude-compatible marketplace index that gives Pi Plugins a supported root-repository source
- keep Codex and Claude marketplace pins synchronized in the existing update workflow
- validate dual-host manifests in CI and document Pi installation

## Verification

- `node scripts/validate-marketplace.mjs`
- negative fixture rejects an unsupported Claude source type
- both GitHub workflow YAML files parse successfully
- isolated `@nklisch/pi-plugins` 0.3.5 exercise discovers `nmg-sdlc@nmg-plugins`
- isolated install settles as `ready` at 2.1.0, activates 13 skills, and exposes sampled SDLC commands

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added marketplace support for Claude-compatible plugin discovery and installation.
  - Added Pi installation guidance, including marketplace registration and user-scoped plugin setup.
  - Added synchronized marketplace metadata for the `nmg-sdlc` plugin.

- **Bug Fixes**
  - Improved marketplace synchronization to detect missing or inconsistent plugin entries.

- **Documentation**
  - Updated project guidance to explain Codex, Claude, and Pi marketplace compatibility.

- **Chores**
  - Added automated validation for marketplace manifests and synchronization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->