### PR TITLE
feat: add first-class OMP marketplace catalog (#166)

### DIFF
--- a/.github/workflows/sync-nmg-sdlc-pointer.yml
+++ b/.github/workflows/sync-nmg-sdlc-pointer.yml
@@ -80,6 +80,7 @@ jobs:
           for (const path of [
             ".agents/plugins/marketplace.json",
             ".claude-plugin/marketplace.json",
+            ".omp-plugin/marketplace.json",
           ]) {
             const manifest = JSON.parse(fs.readFileSync(path, "utf8"));
             const plugin = manifest.plugins?.find((entry) => entry.name === "nmg-sdlc");
@@ -109,13 +110,14 @@ jobs:
           set -euo pipefail
           if git diff --quiet -- \
             .agents/plugins/marketplace.json \
-            .claude-plugin/marketplace.json; then
+            .claude-plugin/marketplace.json \
+            .omp-plugin/marketplace.json; then
             echo "nmg-sdlc marketplace pointer already matches ${VERSION} (${SHA})."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .agents/plugins/marketplace.json .claude-plugin/marketplace.json
+          git add .agents/plugins/marketplace.json .claude-plugin/marketplace.json .omp-plugin/marketplace.json
           git commit -m "chore: sync nmg-sdlc marketplace pointer to ${VERSION}"
           git push origin HEAD:main

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".agents/plugins/marketplace.json"
       - ".claude-plugin/marketplace.json"
+      - ".omp-plugin/marketplace.json"
       - "scripts/validate-marketplace.mjs"
       - ".github/workflows/validate-marketplace.yml"
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - ".agents/plugins/marketplace.json"
       - ".claude-plugin/marketplace.json"
+      - ".omp-plugin/marketplace.json"
       - "scripts/validate-marketplace.mjs"
       - ".github/workflows/validate-marketplace.yml"
   workflow_dispatch:

--- a/.omp-plugin/marketplace.json
+++ b/.omp-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "nmg-plugins",
+  "owner": {
+    "name": "Nunley Media Group"
+  },
+  "metadata": {
+    "description": "Nunley Media Group plugins for structured software delivery"
+  },
+  "plugins": [
+    {
+      "name": "nmg-sdlc",
+      "description": "Stack-agnostic BDD spec-driven development toolkit",
+      "version": "2.1.0",
+      "homepage": "https://github.com/Nunley-Media-Group/nmg-sdlc",
+      "repository": "https://github.com/Nunley-Media-Group/nmg-sdlc",
+      "license": "MIT",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Nunley-Media-Group/nmg-sdlc.git",
+        "ref": "main",
+        "sha": "7675f0e0c01d4b3d9fbcca379c8b9ec9a69bc892"
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Codex plugin marketplace repository for Nunley Media Group. Each listed plugin lives in its own GitHub repository and is referenced from `.agents/plugins/marketplace.json` using Git-backed marketplace entries. Currently listed:
+Plugin marketplace repository for Nunley Media Group. Each listed plugin lives in its own GitHub repository and is referenced from host-specific catalogs. Currently listed:
 
 - [`nmg-sdlc`](https://github.com/Nunley-Media-Group/nmg-sdlc) — BDD spec-driven development workflow (issues, specs, verification, PRs).
 
@@ -10,7 +10,8 @@ Codex plugin marketplace repository for Nunley Media Group. Each listed plugin l
 
 ```
 .agents/plugins/marketplace.json  — Codex marketplace index (Git-backed plugin entries)
-.claude-plugin/marketplace.json   — Claude-compatible index consumed by Pi plugin managers
+.omp-plugin/marketplace.json      — Preferred Oh My Pi marketplace catalog
+.claude-plugin/marketplace.json   — Claude-compatible index consumed by Pi and as OMP fallback
 README.md                         — Public docs: how to add the marketplace, plugin pointers
 ```
 
@@ -24,7 +25,7 @@ When adding or removing a plugin:
      `{"source": {"source": "url", "url": "https://github.com/owner/name.git", "ref": "main"}}`
    - If the plugin lives in a subdirectory, use `source: "git-subdir"` with a `path`
    - Include `policy.installation`, `policy.authentication`, and `category` on every entry
-2. Keep the matching entry in `.claude-plugin/marketplace.json` synchronized for Pi compatibility.
+2. Keep the matching entries in `.omp-plugin/marketplace.json` and `.claude-plugin/marketplace.json` synchronized for Oh My Pi and Pi compatibility.
 3. Run `node scripts/validate-marketplace.mjs`.
 4. Update `README.md` to list the plugin and its source repo.
 5. Open a PR.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nmg-plugins
 
-Codex- and Pi-compatible plugin marketplace by Nunley Media Group.
+Codex-, Oh My Pi-, and Pi-compatible plugin marketplace by Nunley Media Group.
 
 ## Plugins
 
@@ -22,6 +22,22 @@ codex plugin install nmg-sdlc@nmg-plugins
 
 This marketplace uses Git-backed Codex entries, so each plugin can stay in its own repository. For private repos, ensure your Git credentials have read access to both the marketplace repo and the plugin repositories.
 
+### Oh My Pi
+
+OMP prefers `.omp-plugin/marketplace.json` and falls back to `.claude-plugin/marketplace.json`:
+
+```bash
+omp plugin marketplace add Nunley-Media-Group/nmg-plugins
+omp plugin install --scope user nmg-sdlc@nmg-plugins
+```
+
+In the TUI:
+
+```text
+/marketplace add Nunley-Media-Group/nmg-plugins
+/marketplace install nmg-sdlc@nmg-plugins
+```
+
 ### Pi
 
 Install a compatible Pi plugin manager, add this marketplace, then install nmg-sdlc:
@@ -32,7 +48,7 @@ pi install npm:@nklisch/pi-plugins
 /plugins add nmg-sdlc@nmg-plugins --scope user
 ```
 
-The Claude-compatible marketplace index supplies Pi's root-repository source representation while the Codex index remains authoritative for Codex consumers.
+The OMP catalog is the preferred Oh My Pi index. The Claude-compatible catalog remains the Pi fallback. The Codex index remains authoritative for Codex consumers.
 
 ## Updating
 
@@ -40,8 +56,10 @@ The `nmg-sdlc` entry is pinned to the latest `main` commit by a GitHub Actions w
 
 ```bash
 codex plugin marketplace upgrade nmg-plugins
+omp plugin marketplace update nmg-plugins
+omp plugin upgrade --scope user nmg-sdlc@nmg-plugins
 ```
 
 ## Documentation
 
-Each plugin's full docs (workflow, skills reference, configuration) live in its own repository. This repo stays thin and only publishes the marketplace index that points Codex at those plugin repos.
+Each plugin's full docs (workflow, skills reference, configuration) live in its own repository. This repo stays thin and only publishes the marketplace indexes that point Codex, Oh My Pi, and Pi at those plugin repos.

--- a/scripts/validate-marketplace.mjs
+++ b/scripts/validate-marketplace.mjs
@@ -4,8 +4,23 @@ import { readFileSync } from "node:fs";
 
 const CODEX_PATH = ".agents/plugins/marketplace.json";
 const CLAUDE_PATH = ".claude-plugin/marketplace.json";
+const OMP_PATH = ".omp-plugin/marketplace.json";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
-const CLAUDE_SOURCE_TYPES = new Set(["github", "url", "git-subdir", "npm"]);
+const NAME_SEGMENT = /^[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$/;
+const COMPATIBLE_SOURCE_TYPES = new Set(["github", "url", "git-subdir", "npm"]);
+
+const COMPATIBLE_CATALOGS = [
+  {
+    path: CLAUDE_PATH,
+    label: "Claude",
+    requireSkillsMetadata: true,
+  },
+  {
+    path: OMP_PATH,
+    label: "OMP",
+    requireSkillsMetadata: false,
+  },
+];
 
 function readManifest(path) {
   let value;
@@ -21,6 +36,14 @@ function readManifest(path) {
     throw new Error(`${path} requires a string name and plugins array`);
   }
   return value;
+}
+
+function assertNameSegment(value, path, field) {
+  if (typeof value !== "string" || !NAME_SEGMENT.test(value)) {
+    throw new Error(
+      `${path} ${field} must be a lowercase name segment (max 64 chars)`,
+    );
+  }
 }
 
 function entriesByName(manifest, path) {
@@ -49,40 +72,53 @@ function validatePinnedSource(source, path, pluginName) {
   }
 }
 
-const codex = readManifest(CODEX_PATH);
-const claude = readManifest(CLAUDE_PATH);
-if (codex.name !== claude.name) {
-  throw new Error(`marketplace names differ: ${codex.name} != ${claude.name}`);
-}
+function validateCompatibleCatalog(catalog, spec, codex, codexEntries) {
+  if (codex.name !== catalog.name) {
+    throw new Error(`marketplace names differ: ${codex.name} != ${catalog.name} (${spec.path})`);
+  }
+  assertNameSegment(catalog.name, spec.path, "name");
+  if (!catalog.owner || typeof catalog.owner !== "object" || typeof catalog.owner.name !== "string") {
+    throw new Error(`${spec.path} requires owner.name`);
+  }
 
-const codexEntries = entriesByName(codex, CODEX_PATH);
-const claudeEntries = entriesByName(claude, CLAUDE_PATH);
-for (const [name, codexEntry] of codexEntries) {
-  const claudeEntry = claudeEntries.get(name);
-  if (!claudeEntry) {
-    throw new Error(`${CLAUDE_PATH} is missing plugin ${name}`);
-  }
-  validatePinnedSource(codexEntry.source, CODEX_PATH, name);
-  validatePinnedSource(claudeEntry.source, CLAUDE_PATH, name);
-  if (!CLAUDE_SOURCE_TYPES.has(claudeEntry.source.source)) {
-    throw new Error(`${CLAUDE_PATH} plugin ${name} has unsupported source type ${claudeEntry.source.source}`);
-  }
-  for (const field of ["url", "ref", "sha"]) {
-    if (codexEntry.source[field] !== claudeEntry.source[field]) {
-      throw new Error(`plugin ${name} source.${field} differs between marketplace manifests`);
+  const entries = entriesByName(catalog, spec.path);
+  for (const [name, codexEntry] of codexEntries) {
+    const entry = entries.get(name);
+    if (!entry) {
+      throw new Error(`${spec.path} is missing plugin ${name}`);
+    }
+    assertNameSegment(entry.name, spec.path, `plugin ${name}`);
+    validatePinnedSource(codexEntry.source, CODEX_PATH, name);
+    validatePinnedSource(entry.source, spec.path, name);
+    if (!COMPATIBLE_SOURCE_TYPES.has(entry.source.source)) {
+      throw new Error(`${spec.path} plugin ${name} has unsupported source type ${entry.source.source}`);
+    }
+    for (const field of ["url", "ref", "sha"]) {
+      if (codexEntry.source[field] !== entry.source[field]) {
+        throw new Error(`plugin ${name} source.${field} differs between ${CODEX_PATH} and ${spec.path}`);
+      }
+    }
+    if (codexEntry["x-version"] !== entry.version) {
+      throw new Error(`plugin ${name} version differs between ${CODEX_PATH} and ${spec.path}`);
+    }
+    if (spec.requireSkillsMetadata && (entry.strict !== false || entry.skills !== "./skills")) {
+      throw new Error(`${spec.path} plugin ${name} must declare non-strict ./skills runtime metadata`);
     }
   }
-  if (codexEntry["x-version"] !== claudeEntry.version) {
-    throw new Error(`plugin ${name} version differs between marketplace manifests`);
+  for (const name of entries.keys()) {
+    if (!codexEntries.has(name)) {
+      throw new Error(`${CODEX_PATH} is missing plugin ${name} required by ${spec.path}`);
+    }
   }
-  if (claudeEntry.strict !== false || claudeEntry.skills !== "./skills") {
-    throw new Error(`${CLAUDE_PATH} plugin ${name} must declare non-strict ./skills runtime metadata`);
-  }
-}
-for (const name of claudeEntries.keys()) {
-  if (!codexEntries.has(name)) {
-    throw new Error(`${CODEX_PATH} is missing plugin ${name}`);
-  }
+  return entries;
 }
 
-console.log(`Validated ${codexEntries.size} synchronized Codex/Claude marketplace plugin(s).`);
+const codex = readManifest(CODEX_PATH);
+const codexEntries = entriesByName(codex, CODEX_PATH);
+for (const spec of COMPATIBLE_CATALOGS) {
+  validateCompatibleCatalog(readManifest(spec.path), spec, codex, codexEntries);
+}
+
+console.log(
+  `Validated ${codexEntries.size} synchronized Codex/Claude/OMP marketplace plugin(s).`,
+);


### PR DESCRIPTION
## Summary

- add a first-class `.omp-plugin/marketplace.json` catalog so Oh My Pi reads the preferred marketplace path
- keep Codex, Claude, and OMP marketplace pins synchronized in validation and the pointer workflow
- document OMP add/install/upgrade commands while preserving Codex and Pi consumers

> **No spec files found — acceptance criteria extracted from issue body**

## Acceptance Criteria

From issue body:

- [x] AC1: OMP loads `.omp-plugin/marketplace.json` and exposes `nmg-sdlc`
- [x] AC2: Codex, Claude, and OMP catalogs stay on the same `url`, `ref`, `sha`, and version
- [x] AC3: Missing OMP catalog or unsupported source type fails validation
- [x] AC4: Existing Codex and Pi installation workflows remain intact

## Test Plan

- [x] `node scripts/validate-marketplace.mjs`
- [x] OMP `parseMarketplaceCatalog` accepts `.omp-plugin/marketplace.json`
- [x] Negative fixture rejects unsupported OMP source type `local`
- [x] Negative fixture rejects a missing `.omp-plugin/marketplace.json`
- [x] GitHub workflow YAML files parse

Closes #166
